### PR TITLE
Oracle Experiment script for constrained beam search (first pass)

### DIFF
--- a/data/bart-large-xsum/test_annotations.json
+++ b/data/bart-large-xsum/test_annotations.json
@@ -1,0 +1,45 @@
+{
+    "34361828": {
+        "summary": "A search is under way for the remains of a Pembrokeshire village which was wiped out by storms in the 1970s.",
+        "non_factual_hallucinations": [
+            "Pembrokeshire",
+            "Gwynedd"
+        ]
+    },
+    "36456002": {
+        "summary": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup warm-up.",
+        "non_factual_hallucinations": [
+            "World Cup"
+        ]
+    },
+    "24403775": {
+        "summary": "Villagers in Shropshire are calling for the reopening of a dual carriageway next to Stonehenge.",
+        "non_factual_hallucinations": [
+            "Shropshire",
+            "Shrewsbury"
+        ]
+    },
+    "32112735": {
+        "summary": "Liam Payne and Niall Horan have confirmed they're staying in One Direction.",
+        "non_factual_hallucinations": [
+            "Niall Horan"
+        ]
+    },
+    "36203675": {
+        "summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol.",
+        "non_factual_hallucinations": [
+            "the University of Bristol"
+        ]
+    },
+    "17996567": {
+        "summary": "Plans to cut home-to-school transport subsidies in Gloucestershire have been put on hold.",
+        "non_factual_hallucinations": [
+            "Gloucestershire",
+            "Flintshire",
+            "Staffordshire",
+            "Gloucesterse",
+            "Gloucestersfield",
+            "Gloucestersshire"
+        ]
+    }
+}

--- a/data/bart-large-xsum/test_annotations_constrained-10-beams.json
+++ b/data/bart-large-xsum/test_annotations_constrained-10-beams.json
@@ -1,0 +1,75 @@
+{
+    "34361828": {
+        "original_summary": "A search is under way for the remains of a Pembrokeshire village which was wiped out by storms in the 1970s.",
+        "corrected_summary": "A search is under way for the remains of a Neath Port Talbot village which was wiped out by storms more than 100 years ago.",
+        "search_metadata": {
+            "n_words_checked": 223,
+            "dropped_seqs": [
+                "</s>The remains of a Gwynedd",
+                "</s>Remains of a Gwynedd",
+                "</s>The remains of a Pembrokeshire",
+                "</s>A search is under way for the remains of a Gwynedd",
+                "</s>Archaeologists are searching for the remains of a Gwynedd",
+                "</s>A search is under way to find the remains of a Gwynedd",
+                "</s>A search is under way for the remains of a Pembrokeshire"
+            ]
+        }
+    },
+    "36456002": {
+        "original_summary": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup warm-up.",
+        "corrected_summary": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup warm-up.",
+        "search_metadata": {
+            "n_words_checked": 226,
+            "dropped_seqs": []
+        }
+    },
+    "24403775": {
+        "original_summary": "Villagers in Shropshire are calling for the reopening of a dual carriageway next to Stonehenge.",
+        "corrected_summary": "A campaign has been launched to get Stonehenge Bottom's dual carriageway re-opened.",
+        "search_metadata": {
+            "n_words_checked": 217,
+            "dropped_seqs": [
+                "</s>Villagers in Shropshire",
+                "</s>Villagers in Shrewsbury",
+                "</s>Motorists in Shropshire",
+                "</s>Motorists in Shrewsbury"
+            ]
+        }
+    },
+    "32112735": {
+        "original_summary": "Liam Payne and Niall Horan have confirmed they're staying in One Direction.",
+        "corrected_summary": "Liam Payne and Niall Horan have confirmed they're staying in One Direction.",
+        "search_metadata": {
+            "n_words_checked": 212,
+            "dropped_seqs": []
+        }
+    },
+    "36203675": {
+        "original_summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol.",
+        "corrected_summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol.",
+        "search_metadata": {
+            "n_words_checked": 245,
+            "dropped_seqs": []
+        }
+    },
+    "17996567": {
+        "original_summary": "Plans to cut home-to-school transport subsidies in Gloucestershire have been put on hold.",
+        "corrected_summary": "Plans to cut home-to-school transport subsidies for children in Nottinghamshire have been put on hold.",
+        "search_metadata": {
+            "n_words_checked": 218,
+            "dropped_seqs": [
+                "</s>Plans to cut home-to-school transport for children in Flintshire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Flintshire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Staffordshire",
+                "</s>Plans to cut home-to-school transport for children in Gloucestershire",
+                "</s>Proposals to cut home-to-school transport subsidies for children in Flintshire",
+                "</s>Proposals to cut home-to-school transport subsidies for children in Staffordshire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Gloucestershire",
+                "</s>Plans to cut home-to-school transport costs for children in Gloucestershire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Gloucesterse",
+                "</s>Proposals to cut home-to-school transport subsidies for children in Gloucestershire",
+                "</s>Proposals to cut home-to-school transport costs for children in Gloucestershire"
+            ]
+        }
+    }
+}

--- a/data/bart-large-xsum/test_annotations_constrained.json
+++ b/data/bart-large-xsum/test_annotations_constrained.json
@@ -1,0 +1,64 @@
+{
+    "34361828": {
+        "original_summary": "A search is under way for the remains of a Pembrokeshire village which was wiped out by storms in the 1970s.",
+        "corrected_summary": "A search is under way to find the remains of a Gower village which was destroyed by storms more than 100 years ago.",
+        "search_metadata": {
+            "n_words_checked": 88,
+            "dropped_seqs": [
+                "</s>A search is under way for the remains of a Gwynedd",
+                "</s>A search is under way for the remains of a Pembrokeshire"
+            ]
+        }
+    },
+    "36456002": {
+        "original_summary": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup warm-up.",
+        "corrected_summary": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup warm-up.",
+        "search_metadata": {
+            "n_words_checked": 86,
+            "dropped_seqs": []
+        }
+    },
+    "24403775": {
+        "original_summary": "Villagers in Shropshire are calling for the reopening of a dual carriageway next to Stonehenge.",
+        "corrected_summary": "A campaign has been launched to get Stonehenge Bottom's main road re-opened after it was closed to traffic.",
+        "search_metadata": {
+            "n_words_checked": 82,
+            "dropped_seqs": [
+                "</s>Villagers in Shropshire",
+                "</s>Villagers in Shrewsbury"
+            ]
+        }
+    },
+    "32112735": {
+        "original_summary": "Liam Payne and Niall Horan have confirmed they're staying in One Direction.",
+        "corrected_summary": "Liam Payne and Niall Horan have confirmed they're staying in One Direction.",
+        "search_metadata": {
+            "n_words_checked": 87,
+            "dropped_seqs": []
+        }
+    },
+    "36203675": {
+        "original_summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol.",
+        "corrected_summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol.",
+        "search_metadata": {
+            "n_words_checked": 100,
+            "dropped_seqs": []
+        }
+    },
+    "17996567": {
+        "original_summary": "Plans to cut home-to-school transport subsidies in Gloucestershire have been put on hold.",
+        "corrected_summary": "<Failed generation: blocked all beams>",
+        "search_metadata": {
+            "n_words_checked": 79,
+            "dropped_seqs": [
+                "</s>Plans to cut home-to-school transport subsidies in Gloucestershire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Flintshire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Staffordshire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Gloucestershire",
+                "</s>Plans to cut home-to-school transport subsidies for children in Gloucesterse",
+                "</s>Plans to cut home-to-school transport subsidies for children in Gloucestersfield",
+                "</s>Plans to cut home-to-school transport subsidies for children in Gloucestersshire"
+            ]
+        }
+    }
+}

--- a/oracle_experiment.py
+++ b/oracle_experiment.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--output_file", 
         type=str, 
-        default="data/bart-large-xsum/test_annotations_constrained.json"
+        default="data/bart-large-xsum/test_annotations_constrained-10-beams.json"
     )
     args = parser.parse_args()
 
@@ -46,7 +46,7 @@ if __name__ == "__main__":
             word for word in annotation["non_factual_hallucinations"]
         }
 
-    num_beams = 4
+    num_beams = 10
     factuality_enforcer = WordLogitsProcessor(
         tokenizer,
         num_beams,

--- a/oracle_experiment.py
+++ b/oracle_experiment.py
@@ -1,0 +1,80 @@
+from datasets import load_dataset
+import argparse
+from src.generation_utils import load_model_and_tokenizer, generate_summaries
+import json
+from src.beam_validators import BannedWords
+from src.word_logits_processor import WordLogitsProcessor
+
+
+def load_annotations(fname):
+    with open(fname, "r") as f:
+        return json.load(f)
+
+def write_results(fname, results):
+    with open(fname, "w") as f:
+        json.dump(results, f, indent=4)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="facebook/bart-large-xsum")
+    parser.add_argument(
+        "--oracle_data", 
+        type=str, 
+        default="data/bart-large-xsum/test_annotations.json"
+    )
+    parser.add_argument(
+        "--output_file", 
+        type=str, 
+        default="data/bart-large-xsum/test_annotations_constrained.json"
+    )
+    args = parser.parse_args()
+
+    print("Loading model...")
+    model, tokenizer = load_model_and_tokenizer(args.model_path)
+
+    xsum_test = load_dataset("xsum")["test"]
+    xsum_test_by_id = {doc["id"]: doc for doc in xsum_test}
+    oracle_annotations = load_annotations(args.oracle_data)
+
+    docs_to_summarize = []
+    banned_words_by_input_idx = {}
+    for j, (xsum_id, annotation) in enumerate(oracle_annotations.items()):
+        docs_to_summarize.append(
+            xsum_test_by_id[xsum_id]["document"]
+        )
+        banned_words_by_input_idx[j] = {
+            word for word in annotation["non_factual_hallucinations"]
+        }
+
+    num_beams = 4
+    factuality_enforcer = WordLogitsProcessor(
+        tokenizer,
+        num_beams,
+        BannedWords(banned_words_by_input_idx=banned_words_by_input_idx),
+    )
+    summaries, metadata = generate_summaries(
+        model, 
+        tokenizer, 
+        docs_to_summarize, 
+        factuality_enforcer,
+        num_beams=num_beams,
+        return_beam_metadata=True
+    )
+
+    results = {}
+    for j, (xsum_id, annotation) in enumerate(oracle_annotations.items()):
+        results[xsum_id] = {
+            "original_summary": annotation["summary"],
+            "corrected_summary": summaries[j],
+            "search_metadata": {
+                "n_words_checked": metadata[j]["n_words_checked"],
+                "dropped_seqs": [
+                    tokenizer.decode(dropped_seq[0]) for dropped_seq in metadata[j]["dropped_seqs"]
+                ]
+            } 
+        }
+
+    write_results(
+        args.output_file,
+        results
+    )

--- a/src/beam_validators.py
+++ b/src/beam_validators.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Dict
 
 
 class WordValidator(ABC):
@@ -16,11 +18,18 @@ class WordValidator(ABC):
 
 
 class BannedWords(WordValidator):
-    def __init__(self, dictionary):
-        self.dictionary = dictionary
+    def __init__(
+        self, 
+        banned_words=set(), 
+        banned_words_by_input_idx: Dict[int, set] = {}
+    ):
+        self.banned_words = defaultdict(
+            lambda: banned_words,
+            banned_words_by_input_idx
+        )
 
     def is_valid_word(self, word, input_idx, beam_sequence, beam_scores):
-        return word not in self.dictionary
+        return word not in self.banned_words[input_idx]
 
 
 class OverlapValidator(WordValidator):


### PR DESCRIPTION
- Added data/bart-large-xsum with manual annoations
- Refactored BannedWords to support banned_words_by_input_idx

**Next todos:**
- Add support for blocking out words with spaces (since they are prevalent in the data)
- Output posterior probabilities as part of the generation metadata
- Do NER and extrinsic hallucination check - calculate statistics for NER type