### PR TITLE
Optionally test only on non hallucinated

### DIFF
--- a/data/xent-extended/test-with-probs.json
+++ b/data/xent-extended/test-with-probs.json
@@ -1,0 +1,2059 @@
+[
+  {
+    "source": "Ogwen Valley Mountain Rescue team was called to Yr Elen, in the Carneddau range, at about 14:00 GMT on Saturday.\nThe man, who had rib and back injuries, was flown to hospital in a rescue helicopter.",
+    "reference": "A man in his 60s has been airlifted to hospital after falling while walking in Snowdonia.",
+    "prediction": "A man has been airlifted to hospital after falling from a cliff in Gwynedd.",
+    "entities": [
+      {
+        "ent": "Gwynedd",
+        "type": "GPE",
+        "start": 67,
+        "end": 74,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 8.462425284960773e-07,
+        "posterior_prob": 0.31796881556510925
+      }
+    ]
+  },
+  {
+    "source": "Media playback is not supported on this device\nDusmatov, 23, was awarded a unanimous points victory - two judges scoring the fight 30-27, and one 29-28.\nMartinez, 24, is the first Olympic boxing finalist from Colombia.\nThe United States' Nico Hernandez, 20, and 19-year-old Cuban world champion Joahnys Argilagos took bronze after losing in the semi-finals.\nFind out how to get into boxing with our special guide.\nSubscribe to the BBC Sport newsletter to get our pick of news, features and video sent to your inbox.",
+    "reference": "Uzbekistan's Hasanboy Dusmatov won Olympic gold in the men's light-flyweight with victory over Colombian Yuberjen Herney Martinez.",
+    "prediction": "Colombia's Omar Martinez lost to Kazakhstan's Islam Dusmatov in the Olympic men's flyweight final in Rio.",
+    "entities": [
+      {
+        "ent": "Omar",
+        "type": "PERSON",
+        "start": 11,
+        "end": 15,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.02489890344440937,
+        "posterior_prob": 0.03602323681116104
+      }
+    ]
+  },
+  {
+    "source": "Media playback is not supported on this device\nDusmatov, 23, was awarded a unanimous points victory - two judges scoring the fight 30-27, and one 29-28.\nMartinez, 24, is the first Olympic boxing finalist from Colombia.\nThe United States' Nico Hernandez, 20, and 19-year-old Cuban world champion Joahnys Argilagos took bronze after losing in the semi-finals.\nFind out how to get into boxing with our special guide.\nSubscribe to the BBC Sport newsletter to get our pick of news, features and video sent to your inbox.",
+    "reference": "Uzbekistan's Hasanboy Dusmatov won Olympic gold in the men's light-flyweight with victory over Colombian Yuberjen Herney Martinez.",
+    "prediction": "Colombia's Carlos Martinez has been beaten in the Olympic men's flyweight final by Uzbekistan's Islam Dusmatov.",
+    "entities": [
+      {
+        "ent": "Uzbekistan",
+        "type": "GPE",
+        "start": 83,
+        "end": 93,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.09728862345218658,
+        "posterior_prob": 0.1536029875278473
+      }
+    ]
+  },
+  {
+    "source": "Media playback is not supported on this device\nDusmatov, 23, was awarded a unanimous points victory - two judges scoring the fight 30-27, and one 29-28.\nMartinez, 24, is the first Olympic boxing finalist from Colombia.\nThe United States' Nico Hernandez, 20, and 19-year-old Cuban world champion Joahnys Argilagos took bronze after losing in the semi-finals.\nFind out how to get into boxing with our special guide.\nSubscribe to the BBC Sport newsletter to get our pick of news, features and video sent to your inbox.",
+    "reference": "Uzbekistan's Hasanboy Dusmatov won Olympic gold in the men's light-flyweight with victory over Colombian Yuberjen Herney Martinez.",
+    "prediction": "Colombia's Gabriel Martinez has been beaten in the Olympic men's flyweight final by Uzbekistan's Islam Dusmatov.",
+    "entities": [
+      {
+        "ent": "Gabriel",
+        "type": "PERSON",
+        "start": 11,
+        "end": 18,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.00958612933754921,
+        "posterior_prob": 0.0069779590703547
+      }
+    ]
+  },
+  {
+    "source": "Media playback is not supported on this device\nDusmatov, 23, was awarded a unanimous points victory - two judges scoring the fight 30-27, and one 29-28.\nMartinez, 24, is the first Olympic boxing finalist from Colombia.\nThe United States' Nico Hernandez, 20, and 19-year-old Cuban world champion Joahnys Argilagos took bronze after losing in the semi-finals.\nFind out how to get into boxing with our special guide.\nSubscribe to the BBC Sport newsletter to get our pick of news, features and video sent to your inbox.",
+    "reference": "Uzbekistan's Hasanboy Dusmatov won Olympic gold in the men's light-flyweight with victory over Colombian Yuberjen Herney Martinez.",
+    "prediction": "Colombia's Jose Luis Martinez has been beaten in the Olympic men's flyweight final by Uzbekistan's Islam Dusmatov.",
+    "entities": [
+      {
+        "ent": "Jose",
+        "type": "PERSON",
+        "start": 11,
+        "end": 15,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.008900336921215057,
+        "posterior_prob": 0.07468397170305252
+      },
+      {
+        "ent": "Luis",
+        "type": "PERSON",
+        "start": 16,
+        "end": 20,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.01780100353062153,
+        "posterior_prob": 0.11379808932542801
+      }
+    ]
+  },
+  {
+    "source": "Media playback is not supported on this device\nDusmatov, 23, was awarded a unanimous points victory - two judges scoring the fight 30-27, and one 29-28.\nMartinez, 24, is the first Olympic boxing finalist from Colombia.\nThe United States' Nico Hernandez, 20, and 19-year-old Cuban world champion Joahnys Argilagos took bronze after losing in the semi-finals.\nFind out how to get into boxing with our special guide.\nSubscribe to the BBC Sport newsletter to get our pick of news, features and video sent to your inbox.",
+    "reference": "Uzbekistan's Hasanboy Dusmatov won Olympic gold in the men's light-flyweight with victory over Colombian Yuberjen Herney Martinez.",
+    "prediction": "Colombia's Juan Carlos Martinez won his first Olympic gold medal with a unanimous decision over Uzbekistan's Artur Dusmatov in the men's bantamweight final.",
+    "entities": [
+      {
+        "ent": "Juan",
+        "type": "PERSON",
+        "start": 11,
+        "end": 15,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.010781211778521538,
+        "posterior_prob": 0.31743180751800537
+      },
+      {
+        "ent": "Artur",
+        "type": "PERSON",
+        "start": 109,
+        "end": 114,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0035761718172580004,
+        "posterior_prob": 0.004986427258700132
+      }
+    ]
+  },
+  {
+    "source": "The bird's head and wings became stuck in the wire fence in Bethesda while it was chasing a wood pigeon.\nRSPCA Inspector Mike Pugh, who freed the animal, said: \"The buzzard was feisty, but luckily, had not had much feather damage.\n\"I released the bird back to the wild where he belongs straight away.\"",
+    "reference": "A buzzard has been rescued after becoming trapped between fencing and a wall in Gwynedd.",
+    "prediction": "A buzzard has been rescued after becoming stuck in a fence in County Durham.",
+    "entities": [
+      {
+        "ent": "County Durham",
+        "type": "GPE",
+        "start": 62,
+        "end": 75,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 4.353164513304364e-06,
+        "posterior_prob": 0.005411206278949976
+      }
+    ]
+  },
+  {
+    "source": "A tractor laden with explosives was driven at a military police station, a statement said.\nThe attack happened early on Sunday near the town of Dogubayezit in Agri province, near the border with Iran.\nSince 24 July, Turkey has carried out hundreds of air raids on PKK bases on both sides of the Iraq-Turkey border.\nA Turkish state news agency, Anadolu, said the tractor was carrying two tons of explosives that were detonated by a suicide bomber.\nTurkey's army said in a statement that \"long-range guns\" were also found. Four of the injured were in a serious condition.\nThe statement said the Karabulak Gendarmerie Station was hit at around 03:00 local time on Sunday (midnight GMT).\nImages in the Turkish press showed a badly-damaged building with the roof destroyed.\nOne report said the blast was so strong that houses in a village several hundred metres away were hit by debris and some residents were slightly injured.\nThe Dogan news agency added that militants also set up ambushes on roads to prevent medical teams getting to the scene.\nThere has been no comment from the PKK so far.\nAFP news agency said it would be the first time the group was accused of deploying a suicide bomber during recent clashes.\nTurkey says the group was behind a number of attacks in the last two weeks:\nTurkey's official news agency says about 260 Kurdish fighters have been killed in strikes in northern Iraq and Turkey since 24 July. It has also targeted positions held by the Islamic State group.\nAt least six people were killed and several wounded in further Turkish air strikes on Saturday east of Erbil, said local officials.\nThe pro-PKK Firat news agency described an attack on the village of Zerkel as a \"massacre\".\nIraqi Kurdish President Massoud Barzani said: \"We condemn the bombing, which led to the martyrdom of the citizens of the Kurdish region, and we call on Turkey to not repeat the bombing of civilians.\"\nThe Turkish military on Sunday said it had investigated the incident and dismissed claims that there could have been civilian casualties in Zerkel, Reuters reported.\nTurkey considers both the PKK and IS terrorist organisations.\nThe PKK has been fighting Turkey for an autonomous homeland for the Kurds.\nMore than 40,000 people have been killed and hundreds of thousands displaced since the PKK began an armed uprising in 1984.\nIn 2012, the government and PKK began peace talks and the following year a ceasefire was agreed.\nHowever, the ceasefire ended in effect when Turkey launched raids against Kurdish separatist camps in northern Iraq last month.\nThe raids came after the PKK reportedly killed two Turkish police officers in retaliation for an attack claimed by Islamic State and what the PKK sees as Turkey's collaboration with IS.",
+    "reference": "Two Turkish soldiers have been killed and 31 wounded in a suicide attack by Kurdish PKK militants, the Turkish military says.",
+    "prediction": "At least six people have been killed and more than 30 injured in a suicide bombing in northern Turkey, the army says.",
+    "entities": [
+      {
+        "ent": "more than 30",
+        "type": "CARDINAL",
+        "start": 41,
+        "end": 53,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.021032696589827538,
+        "posterior_prob": 0.02017667144536972
+      }
+    ]
+  },
+  {
+    "source": "A tractor laden with explosives was driven at a military police station, a statement said.\nThe attack happened early on Sunday near the town of Dogubayezit in Agri province, near the border with Iran.\nSince 24 July, Turkey has carried out hundreds of air raids on PKK bases on both sides of the Iraq-Turkey border.\nA Turkish state news agency, Anadolu, said the tractor was carrying two tons of explosives that were detonated by a suicide bomber.\nTurkey's army said in a statement that \"long-range guns\" were also found. Four of the injured were in a serious condition.\nThe statement said the Karabulak Gendarmerie Station was hit at around 03:00 local time on Sunday (midnight GMT).\nImages in the Turkish press showed a badly-damaged building with the roof destroyed.\nOne report said the blast was so strong that houses in a village several hundred metres away were hit by debris and some residents were slightly injured.\nThe Dogan news agency added that militants also set up ambushes on roads to prevent medical teams getting to the scene.\nThere has been no comment from the PKK so far.\nAFP news agency said it would be the first time the group was accused of deploying a suicide bomber during recent clashes.\nTurkey says the group was behind a number of attacks in the last two weeks:\nTurkey's official news agency says about 260 Kurdish fighters have been killed in strikes in northern Iraq and Turkey since 24 July. It has also targeted positions held by the Islamic State group.\nAt least six people were killed and several wounded in further Turkish air strikes on Saturday east of Erbil, said local officials.\nThe pro-PKK Firat news agency described an attack on the village of Zerkel as a \"massacre\".\nIraqi Kurdish President Massoud Barzani said: \"We condemn the bombing, which led to the martyrdom of the citizens of the Kurdish region, and we call on Turkey to not repeat the bombing of civilians.\"\nThe Turkish military on Sunday said it had investigated the incident and dismissed claims that there could have been civilian casualties in Zerkel, Reuters reported.\nTurkey considers both the PKK and IS terrorist organisations.\nThe PKK has been fighting Turkey for an autonomous homeland for the Kurds.\nMore than 40,000 people have been killed and hundreds of thousands displaced since the PKK began an armed uprising in 1984.\nIn 2012, the government and PKK began peace talks and the following year a ceasefire was agreed.\nHowever, the ceasefire ended in effect when Turkey launched raids against Kurdish separatist camps in northern Iraq last month.\nThe raids came after the PKK reportedly killed two Turkish police officers in retaliation for an attack claimed by Islamic State and what the PKK sees as Turkey's collaboration with IS.",
+    "reference": "Two Turkish soldiers have been killed and 31 wounded in a suicide attack by Kurdish PKK militants, the Turkish military says.",
+    "prediction": "A suicide bomber has attacked a police station in northern Turkey, killing at least five people and injuring more than 20, the Turkish army says.",
+    "entities": [
+      {
+        "ent": "at least five",
+        "type": "CARDINAL",
+        "start": 75,
+        "end": 88,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.05281875282526016,
+        "posterior_prob": 0.031191019341349602
+      }
+    ]
+  },
+  {
+    "source": "Lewis, 19, signed a three-year contract with the English Premier League club on Friday, having played three FA Cup games for them last season.\nManager Ray McKinnon has also given a contract to Deniz Mehmet following his departure from Port Vale.\nHibernian midfielder Sam Stanton has also made the move to United on a one-year loan deal.\nThe arrivals come with Cammy Bell, last season's first-choice goalkeeper, possibly leaving Tannadice to return to Kilmarnock.\nBell, 30, is believed to be keen on a move to the Scottish Premiership club.\nMcKinnon said of Lewis: \"I expect him to challenge for the starting position.\n\"Harry comes here as one of the top young goalkeeping prospects in English football.\n\"It says so much about his ambition and desire that he has chosen to come up to Scotland to get first-team involvement.\n\"It is a coup for us to bring him to Tannadice and I am positive we will hear much more about him during his career.\"\nLewis, who has represented England at youth level, joined Southampton from hometown club Shrewsbury Town in 2015, hopes to challenge for starts with the Scottish Championship club.\n\"I am excited at the prospect of being involved in first-team football,\" he told United's website.\n\"I believe I am joining a winning team that will be challenging at the top of the league and want to play my part in helping the club secure the title.\"\nStanton becomes United's ninth summer signing and their fourth of the week.\nThe 24-year-old Mehmet returns to Scottish football after having played with Falkirk before joining Port Vale in January.\nDutch midfielder Jordie Briels also signed on a one-year contract after the 25-year-old left Fortuna Sittard in his homeland.",
+    "reference": "Dundee United have signed their second goalkeeper in a week by bringing in Harry Lewis on loan from Southampton.",
+    "prediction": "Dundee United have signed Southampton goalkeeper Harry Lewis for an undisclosed fee.",
+    "entities": [
+      {
+        "ent": "Dundee United",
+        "type": "GPE",
+        "start": 0,
+        "end": 13,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 1.3665740264581641e-18,
+        "posterior_prob": 1.4017884075734344e-12
+      }
+    ]
+  },
+  {
+    "source": "Media playback is not supported on this device\nRoot, a winner alongside women's captain Charlotte Edwards, averaged almost 95 in Test cricket under Moores, who was dismissed on 9 May.\n\"A lot of credit for that has to go to Peter Moores,\" said the 24-year-old.\n\"Over the past year, he has definitely got the best out of me - along with the rest of the coaching department.\"\nRoot was left out of the England team for the final Test of the Ashes whitewash in January 2014, but was recalled after Moores was appointed coach for the second time a year ago.\nThe Yorkshire right-hander has since amassed 1,135 Test runs.\n\"When I came back from Australia, I realised a lot of the time out there I was trying to work on things I wasn't too good at - and putting all my energy into that, rather than spending more time strengthening the stuff I am good at,\" added Root\n\"Peter saw that - and I simplified things as well.\"\nRoot, named player of the year for the men's side after a vote of cricket media, was last week appointed Test vice-captain by new director of cricket Andrew Strauss.\n\"I was delighted, so I accepted straight away,\" said Root. \"I don't think things will change much - just a bit more responsibility on my part.\n\"If Alastair Cook wants to come up to me for ideas, I will make sure I have something to help him out.\"\nAs well as being named as the women's player of the year, Edwards was presented with a silver cap to mark her 200th game as England captain against New Zealand in February.\nIn addition to leading England to four series wins, Edwards averaged more than 75 in one-day internationals and almost 60 in Twenty20s.",
+    "reference": "Batsman Joe Root has credited sacked coach Peter Moores with the form that resulted in him being named England's player of the year.",
+    "prediction": "England Test batsman Joe Root has praised coach Peter Moores after being named player of the year.",
+    "entities": [
+      {
+        "ent": "England Test",
+        "type": "ORG",
+        "start": 0,
+        "end": 12,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 5.540749043575488e-06,
+        "posterior_prob": 2.474109628280985e-08
+      }
+    ]
+  },
+  {
+    "source": "18 January 2016 Last updated at 20:09 GMT\nBen Frost, 27, barricaded himself into his girlfriend's flat in Princetown on Dartmoor on 18 January.\nHe was arrested two hours after breaking through the roof, Plymouth magistrates heard.\nUnemployed Frost of no fixed address admitted two charges of causing criminal damage and two of threatening behaviour.",
+    "reference": "A man who sparked a drug-fuelled roof-top siege after breaking up with his partner has been given a suspended prison sentence.",
+    "prediction": "A man who barricaded himself into his girlfriend's home and caused \u00a31,000 worth of damage has been jailed for six months.",
+    "entities": [
+      {
+        "ent": "1,000",
+        "type": "MONEY",
+        "start": 68,
+        "end": 73,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.021965457126498222,
+        "posterior_prob": 4.9466994823887944e-05
+      },
+      {
+        "ent": "six months",
+        "type": "DATE",
+        "start": 110,
+        "end": 120,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.004006384406238794,
+        "posterior_prob": 0.08778298646211624
+      }
+    ]
+  },
+  {
+    "source": "The 21-year-old joined Tigers on loan in February, making five appearances, and is one of four uncapped players in the England squad for the summer Tests.\nGenge made his senior debut for Bristol in the 2013-14 British and Irish Cup, and scored six tries in 26 appearances.\n\"Ellis has made a big impression in his time on loan with us,\" said Leicester director of rugby Richard Cockerill.\n\"He is a great young prospect and he seems to have found his home at Leicester in his time on loan with us.\n\"We hope he continues to build on that first impression and we look forward to seeing his development here.\"\nGenge is in the England squad both for Saturday's Test at home to Wales and the June tour of Australia.",
+    "reference": "Leicester Tigers have signed new England loose-head prop Ellis Genge from newly-promoted Bristol.",
+    "prediction": "Leicester Tigers have extended the loan of England back-row Ellis Genge from Bristol until the end of the season.",
+    "entities": [
+      {
+        "ent": "Leicester Tigers",
+        "type": "ORG",
+        "start": 0,
+        "end": 16,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 1.598608745378982e-11,
+        "posterior_prob": 1.173194541514988e-09
+      }
+    ]
+  },
+  {
+    "source": "The 21-year-old joined Tigers on loan in February, making five appearances, and is one of four uncapped players in the England squad for the summer Tests.\nGenge made his senior debut for Bristol in the 2013-14 British and Irish Cup, and scored six tries in 26 appearances.\n\"Ellis has made a big impression in his time on loan with us,\" said Leicester director of rugby Richard Cockerill.\n\"He is a great young prospect and he seems to have found his home at Leicester in his time on loan with us.\n\"We hope he continues to build on that first impression and we look forward to seeing his development here.\"\nGenge is in the England squad both for Saturday's Test at home to Wales and the June tour of Australia.",
+    "reference": "Leicester Tigers have signed new England loose-head prop Ellis Genge from newly-promoted Bristol.",
+    "prediction": "Leicester Tigers have re-signed England winger Ellis Genge from Bristol on a two-year deal.",
+    "entities": [
+      {
+        "ent": "two-year",
+        "type": "DATE",
+        "start": 77,
+        "end": 85,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.2853016257286072,
+        "posterior_prob": 0.34187597036361694
+      }
+    ]
+  },
+  {
+    "source": "I give him the benefit of the doubt - his arguably blas\u00e9 attitude, I think, is a symptom of being consistently called upon to defend his creation.\nHe is the co-creator of Tor, the most popular software available for gaining access to the part of the internet unreachable using a conventional browser - including what is often referred to as the dark or underground web.\nTo some, Tor is a menace: a (largely) impenetrable system that enables some of the most depraved crimes to take place on the internet.\nTo others, it is a lifeline, the only way to safely access the online services that most of us take for granted.\nDingledine would rather we talked about the latter. The scale of the dark web - with its drug deals, weapons sales and child abuse imagery - is insignificant when considered in the bigger picture, he argues.\nBut we must talk about the former. I meet Dingledine at this year's Def Con, the large underground hacking convention held in Las Vegas.\nThe timing was ideal - the event came just over a week after the closure of two huge dark web marketplaces. The biggest, Alphabay, was said to boast more than 200,000 users and $1bn (\u00a30.7bn) a year in revenue.\nDingledine's talk was the day prior to our meeting, and in it he criticised misinformed journalists for sensationalising the size and scale of the dark web.\n\"I think a lot of it comes down to incentive mismatches,\" he tells me, \"where journalists have to create more controversy and get something so that everybody will want to read their article.\n\"The story is privacy is under threat around the world, and that's been the story for a while - so they need a new story.\"\nThe Tor Project's website has a section called \"Abuse FAQ\".\nIt is here the group attempts to address the most controversial side of Tor use: that it is an enabler of criminals intent on carrying out the most shocking and sickening crimes.\nWhen talking about this, Dingledine invokes the \"guns don't kill people\" defence. Tor does not commit crime, he says, criminals do.\n\"I would say that there are bad people on the internet and they're doing bad things, but Tor does not enable them to do the bad things.\n\"It's not like there's a new set of bad people in the world who exist because Tor exists.\"\nI guess not. But I suggest that Tor indisputably provides a way in which a novice can make themselves essentially untraceable online.\n\"I still think that most of the bad stuff on the internet has nothing to do with Tor,\" Dingledine insists.\n\"Most of the bad stuff on the internet is due to huge criminal organisations. There's a lot of crime out there.\"\nIn layman's terms, Tor hides your identity by pinging your connection around many different servers across the world, making your actual location extremely hard to track.\nThere have been rumours that law enforcement has \"cracked\" Tor but, aside from isolated vulnerabilities, Dingledine says the concept remains solid.\n\"As far as I know, no, they haven't [cracked Tor].\n\"Tor is the best option there is out there, but that doesn't mean Tor is perfect. No software is perfect.\"\nAny major busts and arrests have been traced back to human error - good old, old-fashioned policing.\n\"Which is frustrating,\" Dingledine interjects, \"Because the modern police world wants to just click a button and have the bad guy show up. Old-fashioned police work is hard, takes energy.\"\nTor was mentioned in the documents leaked as part of Edward Snowden's whistleblowing in 2014. Under the delicate heading \"Tor Stinks\u2026 but it could be worse\", the National Security Agency (NSA) noted: \"We will never be able to de-anonymise all Tor users all the time.\"\nGiven this, you would think the US (and others) would be taking every step to weaken Tor. Ban it, even. But in fact, the US government has done more than any other to keep it alive - donating several million dollars to Dingledine and team since the project's inception in the nineties.\nHe is confident that funding will continue.\n\"A lot of the US government funding for internet freedom tools comes from Republicans. The current congress is quite supportive of giving people tools to keep people safer on the internet.\"\nThe reason? The FBI, CIA, military and others all value anonymity too. In their ideal world, Tor would exist, but they would hold a secret key to break in.\nIn 2014, Facebook's London team announced it had set up a way for users to access Facebook through Tor. More than a million people use the site in this way every month.\n\"About 97% of Tor traffic has to do with people going to Facebook, and Wikipedia, and BBC, and ordinary websites on the internet, and they want to go there more safely,\" Dingledine says.\n\"Whereas 3% of the traffic has to do with this 'dark web' thing\u2026. I have to wave my hands when I say the phrase.\"\nThe ability to access social networks anonymously is invaluable to people living in oppressive regimes or countries with high levels of surveillance around what citizens do online.\nBut given the majority of users can be found in the US and Europe - in places not typically considered to be oppressive - I argued that Tor's justification hinging on the needs of activists perhaps seems less than convincing.\n\"I think the line is getting a lot more blurry between the free countries, and the un-free countries,\" he says.\n___________\nFollow Dave Lee on Twitter @DaveLeeBBC\nYou can reach Dave securely through encrypted messaging app Signal on: +1 (628) 400-7370",
+    "reference": "When Roger Dingledine talks about the dark web, he waves his hands in the air - as if not quite convinced of its existence.",
+    "prediction": "\"I don't think I've ever had a conversation with someone who doesn't look like a hacker,\" says David Dingledine.",
+    "entities": [
+      {
+        "ent": "David",
+        "type": "PERSON",
+        "start": 95,
+        "end": 100,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.004028867464512587,
+        "posterior_prob": 0.04313100129365921
+      }
+    ]
+  },
+  {
+    "source": "With all the results now declared, Jac Larner of Cardiff University sums up the night for Wales' five main parties.\nWELSH LABOUR\nLabour have exceeded all expectations in Wales.\nThey have outperformed every single Wales-only poll over the course of the campaign - and the exit poll - achieving their highest share of the vote in Wales since 1997.\nNot only did they successfully defend their 25 seats, but they gained three seats from the Conservatives, taking their total to 28 in Wales.\nThis is their best performance in terms of seat share since 2005, and their best performance in terms of share of the Wales vote since the New Labour landslide of 1997.\nThis extends their run of winning general elections in Wales to 26 in a row.\nWELSH CONSERVATIVES\nThe Conservatives also saw their vote share increase across Wales by 6.3%, but this was not enough for them to hold off Labour's surge in Wales.\nEarly in the night they were confident about gaining seats in Bridgend, Newport West and in the north east of Wales, so a net loss of 3 seats will be a big disappointment.\nHistorically, the Conservatives have always performed worse in Wales than in England at every election going back to 1859, and this election looks to be no different.\nPLAID CYMRU\nIt was a strange night for Plaid Cymru that ended in success with the election of their youngest ever MP, Ben Lake.\nThey increased their parliamentary representation, taking Ceredigion from the Liberal Democrats, and their vote held up where they were defending the three seats won in 2015.\nTheir group of four MPs is the party's largest Westminster cohort since the 2001 general election.\nYet their vote share fell nationally by 1.7% and they lost votes in their other target seats of Ynys Mon, Llanelli and Rhondda.\nHowever, Plaid will view themselves as one of the few winners in this election on a night where smaller parties saw their vote share squeezed across the UK.\nLIBERAL DEMOCRATS\nThe Liberal Democrats' torrid time at elections in Wales continues.\nThey won their worst ever share of the vote in the party's history in Wales, and lost their solo MP Mark Williams in Ceredigion to Plaid Cymru.\nWith only one AM in Wales, and limited representation in local government in Wales, the Liberal Democrats can no longer be considered to be a significant political player in the country.\nIt is the first time since the founding of one of the Lib Dem's predecessor party, the Liberals, in 1859 that they will have no Westminster representation in Wales.\nUKIP\nUKIP's vote share has collapsed considerably across Wales, polling 11.6% less than 2015 after 38 constituencies had been called.\nOpinion polling across the campaign suggested that around two-thirds of the 2015 UKIP vote would go to the Conservatives.\nFrom the results we have seen so far, it seems that a significant proportion of these voters have voted for Labour in Wales.",
+    "reference": "It has been a dramatic night that has confounded expectations of political parties and commentators.",
+    "prediction": "The general election has taken place in Wales, with the Labour Party making history by winning a record 26th consecutive general election.",
+    "entities": [
+      {
+        "ent": "the Labour Party",
+        "type": "ORG",
+        "start": 52,
+        "end": 68,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.1144876554608345,
+        "posterior_prob": 0.02071942202746868
+      },
+      {
+        "ent": "26th",
+        "type": "ORDINAL",
+        "start": 104,
+        "end": 108,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.001011742977425456,
+        "posterior_prob": 0.6543523073196411
+      }
+    ]
+  },
+  {
+    "source": "Giving people the right to buy their council houses and shares in previously nationalised firms such as British Telecom and British Gas were among the initiatives that won her much support.\nBut some believe that other changes, such as those that made mortgages and credit much easier to get, sowed the seeds of future crises that still affect many to this day.\nHere, BBC reporters look at some of the changes that, for better or worse, have changed our finances forever.\nBy Brian Milligan, personal finance reporter, BBC News.\nThe Right to Buy Scheme for council houses was one of Margaret Thatcher's most popular policies.\nIt was enshrined in the Housing Act of 1980, making it one of her first major pieces of legislation after she came to office in 1979.\nThe number of people who bought their council house from their local authorities rose to 200,000 by 1982, and again peaked at 180,000 in 1989, her last full year as prime minister.\nSince the Housing Act came into force, it is estimated that some two million homes have been sold to former council tenants.\nThe sale price was based on market valuation, but included substantial discounts, depending on how long a tenant had been living there.\nWhen Labour came to power in 1997, it reduced the value of such discounts in areas where councils were running short of housing stock.\nCritics said the policy resulted in speculators buying up valuable housing stock too cheaply.\nThe Right to Buy Scheme was extended in the March 2013 Budget, as the government vowed to increase sales once again.\nBy Simon Gompertz, personal finance correspondent, BBC News\nBefore Mrs Thatcher arrived at No 10, British passports contained a special page to record the amount of cash travellers took out of the country.\nThe page was one of the first things to be scrapped by the new government, as the Tories moved to abolish exchange controls.\nThe Chancellor, Geoffrey Howe, raised travel allowances to \u00a31,000 per trip and permitted overseas property purchases of up to \u00a3100,000.\nOn the tax front, the basic rate was cut by 3p to 30p in the pound, while the highest rate came down from 83p to 60p.\nBut Thatcher's chancellors not only cut income tax, but also changed the way we pay tax.\nTo fund lower taxes on incomes, up went tax on most things shoppers bought. VAT, or value added tax, jumped from 8% to 15%.\nWithin a few years, the basic rate of tax had fallen to 25%, while the higher rate had been slashed to 40%.\nBy Stephanie FlandersEconomics editor\nWith money from tax cuts in their pockets, shoppers began to rediscover the \"feelgood factor\". They were encouraged further as credit was unleashed.\nRestrictions on hire purchase offers were relaxed, stores offered credit, credit cards boomed. Consumer borrowing tripled during the 1980s.\nAnd, of course, mortgages were easier to get. The old rule of thumb that you only borrow two-and-a-half times salary was thrown out of the window.\nBuilding societies were allowed to lend more and foreign banks set up in the UK to compete.\nThe Bank of England did not control the expansion of credit and there are those who see the roots of the current financial crisis in the credit boom of the Thatcher years.\nMrs Thatcher wanted self-reliance, not reliance on the state. That was the thinking behind the launch of personal pensions in 1988.\nThe new plans provided a route to save for those who did not have a company scheme. But, sadly, they backfired.\nThe promotions and publicity got out of hand. Advisers went to town, encouraging savers to switch out of solid traditional schemes into riskier personal pensions.\nCompensating the victims cost the pensions industry \u00a311bn.\nMore successful were personal equity plans or Peps, designed to encourage savers to salt away up to \u00a36,000 a year in shares, in exchange for a tax break.\nTo complement Peps, John Major, the last chancellor of the Thatcher era, introduced a tax-free vehicle for cash savings, the Tessa.\nThe idea caught on. Peps and Tessas later morphed into individual savings accounts, or Isas, in which Britons have \u00a3390bn salted away.\nBy John Moylan, employment correspondent, BBC News\nFew senior trade union figures have commented on the death of Baroness Thatcher. That silence speaks volumes for the lasting legacy that her reforms had on the power of the movement.\nShe was ushered to power in the wake of the Winter of Discontent when a wave of strikes paralysed many parts of the economy. Rubbish was piled high in the streets as  collections stopped. And famously, gravediggers went on strike.\nThe Conservative government set about a series of changes to employment and trade union laws, which ended mass picketing, secondary action and the closed shop, where staff had to join a union to get a job.\nSecret ballots were introduced, as were restrictions on holding legitimate disputes that still rankle with the unions to this day.\nIn 1979 there were more than 29 million working days lost to strike action. These days, that number is typically well below one million.\nThe miners' strike of 1984-85 came to symbolise the government's battle with the unions. The year-long dispute over pit closures led to repeated scenes of violence as striking miners clashed with police.\nIn the end the miners went back to work. The balance of power in industrial relations had shifted forever.\nUnions insist that the collapse in traditional manufacturing industries during the 1980s did as much to diminish their power. Membership fell from over 12 million in 1980 - today there are fewer than 6 million members of Trades Union Congress-affiliated unions.\nOne of the first actions of the Labour government in 1997 was to repeal the ban on unions at GCHQ - the Government Communications Headquarters - imposed under the Tories. But under New Labour, the main planks of the reforms of the Thatcher years remained unchanged.\nBy Kevin Peachey, personal finance reporter, BBC News\nA policy of privatising the UK's large utilities revolutionised share ownership in the UK, and as such it was widely popular with many, though the initiatives also had their critics.\nThe recession of the early 1980s created the environment that allowed the Conservatives to drive forward the idea of moving nationalised industries into private ownership.\nBy the end of its first term, it had already privatised British Aerospace and Cable & Wireless. British Telecom, British Airways, British Steel, as well as water and electricity firms were among those privatised later.\nThis led to a new wave of first-time shareholders in the UK.\nOne of the first privatisations and arguably the most memorable - through a celebrated advertising campaign - was the sell-off of shares in British Gas in 1986.\nThe promotional campaign featured TV adverts in which characters urged each other to \"tell Sid\" about the chance to buy shares at \"affordable\" prices.\nAnyone who has held on to these shares will now have a portfolio that includes a stake in Centrica, BG Group and National Grid.\nPrivatisation was key to the Thatcher government's economic policy. As a result, it hoped that the large subsidies granted to industry over the decades would be eventually phased out, allowing for further tax cuts and controlling borrowing.\nIt also encouraged the idea of members of the public owning shares in big former monopolies.\nYet, figures from the Office for National Statistics show that the percentage of the UK stock market owned by UK individuals was higher in the 1960s and 1970s in terms of value, than the 1980s.\nIn 1981, 28% was owned by UK individuals. This had fallen to 20% by the end of the Thatcher term in 1990. Yet it fell to just over 11% by the end of 2010.\nBy Rebecca Marston, business reporter, BBC News\nThe impact of one of Margaret Thatcher's deregulation drives was the drastic reorganisation of the way shares were traded in the UK.\nThe so-called \"Big Bang\", introduced on 27 October 1986, made it far simpler to trade shares on the London Stock Exchange.\nThe most visible reform was that traders no longer stalked the floor of the Exchange, animatedly dealing with each other face-to-face.\nBig Bang moved them at a stroke from that to screen-based and telephone trading.\nIt also broke up what many saw as a gentlemen's club, ruled by restrictive practices. (It is worth noting that there were almost no women and the gentlemen described came from a far wider class base than the phrase suggests.)\nBefore Big Bang, share dealing was done through a stockbroker, who advised clients on dealings. Transactions were carried out by jobbers, who made markets in shares - physically seeking out others with whom to trade on the Stock Exchange floor.\nPrice competition was not allowed, fixed commissions were the norm.\nAt best it was a self-regulating club, where bounders could easily be spotted, but at its worst this club fostered insider dealing and share price ramping.\nBig Bang saw many of the City's historic names disappear in a frenzy of takeovers as banks jostled to buy  jobbers and stockbrokers in order to become one-stop shops.\nThis, in turn, unleashed a succession of takeovers by even bigger organisations, the giant American finance houses.\nBig Bang helped facilitate privatisation, demystifying the share-buying process that many ordinary people had found a stumbling block, thus allowing people to simply walk into their banks and order a parcel of shares.\nBut while it made dealing and investing easier, it also paved the way for the creation of giant financial institutions, whose size has meant their health is critical to the wellbeing of the general economy.",
+    "reference": "During her years as prime minister, Margaret Thatcher revolutionised the economic fortunes of every person in the UK.",
+    "prediction": "Margaret Thatcher was prime minister for more than 30 years, and during her time in office she made a number of significant changes to the way we lived and worked.",
+    "entities": [
+      {
+        "ent": "more than 30 years",
+        "type": "DATE",
+        "start": 41,
+        "end": 59,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 9.748967568157241e-05,
+        "posterior_prob": 0.10785502195358276
+      }
+    ]
+  },
+  {
+    "source": "Evidence of suspected match-fixing in elite tennis was revealed this week by a BBC and BuzzFeed News investigation.\n\"Future players will see the headlines and see it's not an option at all,\" doubles representative Fleming told BBC Scotland on Wednesday.\n\"I think if anyone is found to be doing it, that should be them. They shouldn't be playing again.\"\nFleming, 31, and his partner Jonathan Erlich, were beaten 6-4, 3-6, 6-3 in the first round of the Australian Open on Wednesday by Robin Haase and Fernando Verdasco.\n\"The key thing about sport is that it's pure, you don't know the outcome of any given match, and that's what people pay to come and watch,\" he added. \"You never know what's going to happen. That's key  and they have to preserve that.\n\"I've never been approached to take money or anything to fix a match or lose a match. It does go on because people have been banned at lower levels. I'm surprised to see the article come out and talk about higher levels; I certainly haven't been aware of anything going on there.\"\nThe Scot said he had no idea as to the identity of the suspected match-fixers, and suggested additional funding could be granted to the Tennis Integrity Unit (TIU), set-up to police the sport.\n\"Your guess is as good as mine,\" he said of those involved. \"There were no names in the article because it's very difficult to prove anything. I think that's the issue the TIU has in that a match can be reported or look suspicious, but it doesn't necessarily mean players are guilty.\n\"It can just be people throwing money on a match.\"\nFleming was adamant, though, that no such activities were occurring in Melbourne.\n\"I think if you're sitting at home or buying a ticket to come and watch here at the Aussie Open, I've no doubt in my mind you're watching pure sporting theatre,\" he said.\n\"Players going at it and the best player winning on that day. There's no doubt in my mind that is the case here.\"",
+    "reference": "Great Britain's Colin Fleming says tennis players guilty of match-fixing should face life bans.",
+    "prediction": "Former Scottish Open champion Jamie Fleming says anyone found guilty of match-fixing should be banned from the sport.",
+    "entities": [
+      {
+        "ent": "Scottish",
+        "type": "NORP",
+        "start": 7,
+        "end": 15,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0048994156531989574,
+        "posterior_prob": 0.01807720772922039
+      },
+      {
+        "ent": "Jamie",
+        "type": "PERSON",
+        "start": 30,
+        "end": 35,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.016255397349596024,
+        "posterior_prob": 0.0027261103969067335
+      }
+    ]
+  },
+  {
+    "source": "Flint Community Hospital could be closed under plans by Betsi Cadwaladr University Health Board (BCUHB) to reorganise its services in north Wales.\nCampaigners joined a protest march from the hospital to attend the public meeting at the town hall.\nIn a statement BCUHB said retaining the status quo was \"not an option\".\nThe health board, which predicts a financial shortfall of \u00c2\u00a364.6m this year, revealed details of its proposed shake-up in July.\nUnder plans being considered Blaenau Ffestiniog community hospital could also close and minor injury accident departments may shut at other locations.\nNeo-natal intensive care may also be transferred over the border to England as part of the proposed shake-up.\nShortly after the plans were made public GPs in the area revealed their concerns about the effects of proposed cuts on community services.\nMark Scriven, the health board's medical director, said there was sound reasoning behind the proposals to close Flint hospital.\n\"The thinking generally about the problems we're trying to address in these proposals with community hospitals is that some of them are very old, and they have poor fabric,\" he told BBC Radio Wales.\nHe said it was not just the furnishings that were not up to scratch, the physical space did not suit modern health care.\n\"A lot of them, and the services they provide, are underused, and certainly the minor injuries unit at Flint hospital is underused, which is important because it doesn't allow the nurses running it to maintain their experience according to their professional bodies,\" added Mr Scriven.\nIn response, Jack Reece, chairman of the Save Our Cottage Hospital Campaign, said Flint hospital was well used.\nSpeaking at Tuesday protest, he added: \"They've closed us, they took beds away from us. We've had 18 going down to 14, going down to 12, 10.\n\"They're taking away our clinics from there. They have systematically dropped the services from this town.\"\nMr Reece described BCUHB's plans as a new version of old proposals by the Flintshire Health Board which had already been rejected by the Welsh government.\nExplaining the reasons behind its proposed shake-up, BCUHB said it was clear that it could not afford to stand still.\n\"The status quo is not an option,\" the board said.\n\"The proposals we are now making are intended to change the way in which services are provided and where they are provided to ensure patient safety and meet quality standards.\n\"The proposals will allow us to attract and retain the professional clinical staff we need and control our costs when public finances are decreasing.\"\nBCUHB said its consultation exercise would run until 28 October, and it would also take account of the views of the community health council and any views they have heard from the public before making decisions.\nAny changes would start in early 2013, it said.",
+    "reference": "More than 1,000 campaigners trying to save a north Wales community hospital from closure have marched to a health board consultation meeting.",
+    "prediction": "Hundreds of people have attended a public meeting in Flintshire to discuss plans to close a community hospital.",
+    "entities": [
+      {
+        "ent": "Hundreds",
+        "type": "CARDINAL",
+        "start": 0,
+        "end": 8,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 1.3275875971885398e-05,
+        "posterior_prob": 6.050991942174733e-06
+      }
+    ]
+  },
+  {
+    "source": "Flint Community Hospital could be closed under plans by Betsi Cadwaladr University Health Board (BCUHB) to reorganise its services in north Wales.\nCampaigners joined a protest march from the hospital to attend the public meeting at the town hall.\nIn a statement BCUHB said retaining the status quo was \"not an option\".\nThe health board, which predicts a financial shortfall of \u00c2\u00a364.6m this year, revealed details of its proposed shake-up in July.\nUnder plans being considered Blaenau Ffestiniog community hospital could also close and minor injury accident departments may shut at other locations.\nNeo-natal intensive care may also be transferred over the border to England as part of the proposed shake-up.\nShortly after the plans were made public GPs in the area revealed their concerns about the effects of proposed cuts on community services.\nMark Scriven, the health board's medical director, said there was sound reasoning behind the proposals to close Flint hospital.\n\"The thinking generally about the problems we're trying to address in these proposals with community hospitals is that some of them are very old, and they have poor fabric,\" he told BBC Radio Wales.\nHe said it was not just the furnishings that were not up to scratch, the physical space did not suit modern health care.\n\"A lot of them, and the services they provide, are underused, and certainly the minor injuries unit at Flint hospital is underused, which is important because it doesn't allow the nurses running it to maintain their experience according to their professional bodies,\" added Mr Scriven.\nIn response, Jack Reece, chairman of the Save Our Cottage Hospital Campaign, said Flint hospital was well used.\nSpeaking at Tuesday protest, he added: \"They've closed us, they took beds away from us. We've had 18 going down to 14, going down to 12, 10.\n\"They're taking away our clinics from there. They have systematically dropped the services from this town.\"\nMr Reece described BCUHB's plans as a new version of old proposals by the Flintshire Health Board which had already been rejected by the Welsh government.\nExplaining the reasons behind its proposed shake-up, BCUHB said it was clear that it could not afford to stand still.\n\"The status quo is not an option,\" the board said.\n\"The proposals we are now making are intended to change the way in which services are provided and where they are provided to ensure patient safety and meet quality standards.\n\"The proposals will allow us to attract and retain the professional clinical staff we need and control our costs when public finances are decreasing.\"\nBCUHB said its consultation exercise would run until 28 October, and it would also take account of the views of the community health council and any views they have heard from the public before making decisions.\nAny changes would start in early 2013, it said.",
+    "reference": "More than 1,000 campaigners trying to save a north Wales community hospital from closure have marched to a health board consultation meeting.",
+    "prediction": "More than 100 people have attended a public meeting in Wales to discuss plans to close a community hospital.",
+    "entities": [
+      {
+        "ent": "More than 100",
+        "type": "CARDINAL",
+        "start": 0,
+        "end": 13,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 2.538211845148908e-07,
+        "posterior_prob": 7.44987744383252e-07
+      }
+    ]
+  },
+  {
+    "source": "The A344 next to the monument was shut in June to \"restore the dignity\" of the stone circle as part of a \u00c2\u00a327m project.\nResidents of villages including Shrewton and Orcheston say their lanes have become \"rat runs\" for drivers avoiding congestion on the A303.\nCampaigners will collect signatures for a petition this weekend.\nJanice Hassett, from the Shrewton Traffic Action Group (Stag), said: \"The A344 should not have been closed before the A303 was dualled.\n\"The A303 at Stonehenge Bottom was bad before, but it's a nightmare now.\n\"Traffic is stupidly backing up to Thruxton on a holiday weekend.\n\"Sat-navs are sending people right through our villages. There's going to be an accident.\"\nThe petition is asking for \"urgent action\" to be taken to tackle high volumes of non-local traffic using the B3086 through Shrewton, a 20mph speed limit to be introduced and better signage to be installed.",
+    "reference": "People concerned with traffic congestion in villages near Stonehenge are stepping up a campaign for \"urgent action\" to be taken.",
+    "prediction": "Villagers in Shropshire are calling for the reopening of a dual carriageway next to Stonehenge.",
+    "entities": [
+      {
+        "ent": "Shropshire",
+        "type": "GPE",
+        "start": 13,
+        "end": 23,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.002965181600302458,
+        "posterior_prob": 0.6876581907272339
+      }
+    ]
+  },
+  {
+    "source": "The A344 next to the monument was shut in June to \"restore the dignity\" of the stone circle as part of a \u00c2\u00a327m project.\nResidents of villages including Shrewton and Orcheston say their lanes have become \"rat runs\" for drivers avoiding congestion on the A303.\nCampaigners will collect signatures for a petition this weekend.\nJanice Hassett, from the Shrewton Traffic Action Group (Stag), said: \"The A344 should not have been closed before the A303 was dualled.\n\"The A303 at Stonehenge Bottom was bad before, but it's a nightmare now.\n\"Traffic is stupidly backing up to Thruxton on a holiday weekend.\n\"Sat-navs are sending people right through our villages. There's going to be an accident.\"\nThe petition is asking for \"urgent action\" to be taken to tackle high volumes of non-local traffic using the B3086 through Shrewton, a 20mph speed limit to be introduced and better signage to be installed.",
+    "reference": "People concerned with traffic congestion in villages near Stonehenge are stepping up a campaign for \"urgent action\" to be taken.",
+    "prediction": "Villagers in Shrewsbury are calling for the reopening of a dual carriageway next to Stonehenge.",
+    "entities": [
+      {
+        "ent": "Shrewsbury",
+        "type": "GPE",
+        "start": 13,
+        "end": 23,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0015937977004796267,
+        "posterior_prob": 0.03718477860093117
+      }
+    ]
+  },
+  {
+    "source": "Anthony Knockaert headed wide early on but striker Baldock made no mistake shortly after, guiding Gaetan Bong's cross into the top corner.\nHelder Costa came closest to equalising just before the break but his long-range shot was tipped over by Brighton goalkeeper David Stockdale.\nWolves pressed late on with several corners but Brighton held on.\nWalter Zenga's Wolves went into the game having won just two of their past nine away league games with only one clean sheet and they conceded what turned out to be the winning goal after only 16 minutes.\nFull-back Bong whipped in a pinpoint cross which was headed home by Baldock for his third goal in three games as the Seagulls took control before the break.\nTop-scorer Glenn Murray almost doubled Brighton's lead early in the second half but his header was narrowly wide and a minute later Knockaert forced a fine save from Carl Ikeme with a long-range left-footed shot.\nWolves committed men forward late on but, despite a succession of corner kicks in the dying minutes, Albion held on for victory and their eighth clean sheet in 13 games.\nBrighton manager Chris Hughton: \"It is very timely that Sam is in this form and I am very pleased for him. He's been good for us.\n\"He may not score too many with his head but he showed a desire to get across the defender.\n\"He is a team player, works hard for the team and he is at the right place at the right time.\"\nWolves head coach Walter Zenga: \"It was a good game in my opinion but they scored and we didn't. We played at the same level as Brighton.\n\"We were in the game and there was no difference in the teams. I would prefer to play badly and take the points.\n\"In the last four games we have only taken one point, but we must believe in our job.\"\nMatch ends, Brighton and Hove Albion 1, Wolverhampton Wanderers 0.\nSecond Half ends, Brighton and Hove Albion 1, Wolverhampton Wanderers 0.\nAttempt missed. Ivan Cavaleiro (Wolverhampton Wanderers) header from a difficult angle on the right misses to the left. Assisted by Jo\u00e3o Teixeira with a cross following a corner.\nCorner,  Wolverhampton Wanderers. Conceded by Lewis Dunk.\nLewis Dunk (Brighton and Hove Albion) is shown the yellow card.\nJ\u00f3n Dadi B\u00f6dvarsson (Wolverhampton Wanderers) is shown the yellow card.\nCorner,  Wolverhampton Wanderers. Conceded by David Stockdale.\nAttempt saved. H\u00e9lder Costa (Wolverhampton Wanderers) left footed shot from outside the box is saved in the bottom left corner. Assisted by Danny Batth.\nCorner,  Wolverhampton Wanderers. Conceded by Jiri Skalak.\nCorner,  Wolverhampton Wanderers. Conceded by Glenn Murray.\nCorner,  Wolverhampton Wanderers. Conceded by David Stockdale.\nAttempt saved. Danny Batth (Wolverhampton Wanderers) right footed shot from outside the box is saved in the bottom left corner.\nDanny Batth (Wolverhampton Wanderers) wins a free kick in the defensive half.\nFoul by Glenn Murray (Brighton and Hove Albion).\nAttempt saved. Romain Saiss (Wolverhampton Wanderers) left footed shot from outside the box is saved in the bottom left corner.\nSubstitution, Brighton and Hove Albion. S\u00e9bastien Pocognoli replaces Anthony Knockaert.\nCorner,  Wolverhampton Wanderers. Conceded by Steve Sidwell.\nHand ball by Anthony Knockaert (Brighton and Hove Albion).\nJ\u00f3n Dadi B\u00f6dvarsson (Wolverhampton Wanderers) wins a free kick in the attacking half.\nFoul by Oliver Norwood (Brighton and Hove Albion).\nFoul by Romain Saiss (Wolverhampton Wanderers).\nConnor Goldson (Brighton and Hove Albion) wins a free kick on the right wing.\nAttempt saved. Anthony Knockaert (Brighton and Hove Albion) right footed shot from the left side of the box is saved in the bottom left corner. Assisted by Jiri Skalak.\nCorner,  Brighton and Hove Albion. Conceded by Danny Batth.\nSubstitution, Brighton and Hove Albion. Dale Stephens replaces Sam Baldock.\nFoul by Ivan Cavaleiro (Wolverhampton Wanderers).\nJiri Skalak (Brighton and Hove Albion) wins a free kick in the defensive half.\nH\u00e9lder Costa (Wolverhampton Wanderers) wins a free kick on the left wing.\nFoul by Connor Goldson (Brighton and Hove Albion).\nSubstitution, Brighton and Hove Albion. Connor Goldson replaces Bruno because of an injury.\nOffside, Wolverhampton Wanderers. Romain Saiss tries a through ball, but Ivan Cavaleiro is caught offside.\nAttempt missed. Romain Saiss (Wolverhampton Wanderers) left footed shot from outside the box is high and wide to the left. Assisted by Ivan Cavaleiro.\nAttempt missed. Anthony Knockaert (Brighton and Hove Albion) left footed shot from the centre of the box misses to the left. Assisted by Bruno with a cross.\nFoul by Romain Saiss (Wolverhampton Wanderers).\nSam Baldock (Brighton and Hove Albion) wins a free kick in the defensive half.\nJ\u00f3n Dadi B\u00f6dvarsson (Wolverhampton Wanderers) wins a free kick in the defensive half.\nFoul by Steve Sidwell (Brighton and Hove Albion).\nFoul by David Edwards (Wolverhampton Wanderers).\nSteve Sidwell (Brighton and Hove Albion) wins a free kick in the defensive half.\nSubstitution, Wolverhampton Wanderers. Jo\u00e3o Teixeira replaces Nouha Dicko.",
+    "reference": "Sam Baldock's first-half header proved enough to give in-form Brighton a home victory over Wolverhampton Wanderers.",
+    "prediction": "Sam Baldock's first-half header was enough to give Brighton victory over Wolves at the Amex Stadium.",
+    "entities": [
+      {
+        "ent": "first-half",
+        "type": "DATE",
+        "start": 14,
+        "end": 24,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.028251219540834427,
+        "posterior_prob": 0.6802307963371277
+      }
+    ]
+  },
+  {
+    "source": "Anthony Knockaert headed wide early on but striker Baldock made no mistake shortly after, guiding Gaetan Bong's cross into the top corner.\nHelder Costa came closest to equalising just before the break but his long-range shot was tipped over by Brighton goalkeeper David Stockdale.\nWolves pressed late on with several corners but Brighton held on.\nWalter Zenga's Wolves went into the game having won just two of their past nine away league games with only one clean sheet and they conceded what turned out to be the winning goal after only 16 minutes.\nFull-back Bong whipped in a pinpoint cross which was headed home by Baldock for his third goal in three games as the Seagulls took control before the break.\nTop-scorer Glenn Murray almost doubled Brighton's lead early in the second half but his header was narrowly wide and a minute later Knockaert forced a fine save from Carl Ikeme with a long-range left-footed shot.\nWolves committed men forward late on but, despite a succession of corner kicks in the dying minutes, Albion held on for victory and their eighth clean sheet in 13 games.\nBrighton manager Chris Hughton: \"It is very timely that Sam is in this form and I am very pleased for him. He's been good for us.\n\"He may not score too many with his head but he showed a desire to get across the defender.\n\"He is a team player, works hard for the team and he is at the right place at the right time.\"\nWolves head coach Walter Zenga: \"It was a good game in my opinion but they scored and we didn't. We played at the same level as Brighton.\n\"We were in the game and there was no difference in the teams. I would prefer to play badly and take the points.\n\"In the last four games we have only taken one point, but we must believe in our job.\"\nMatch ends, Brighton and Hove Albion 1, Wolverhampton Wanderers 0.\nSecond Half ends, Brighton and Hove Albion 1, Wolverhampton Wanderers 0.\nAttempt missed. Ivan Cavaleiro (Wolverhampton Wanderers) header from a difficult angle on the right misses to the left. Assisted by Jo\u00e3o Teixeira with a cross following a corner.\nCorner,  Wolverhampton Wanderers. Conceded by Lewis Dunk.\nLewis Dunk (Brighton and Hove Albion) is shown the yellow card.\nJ\u00f3n Dadi B\u00f6dvarsson (Wolverhampton Wanderers) is shown the yellow card.\nCorner,  Wolverhampton Wanderers. Conceded by David Stockdale.\nAttempt saved. H\u00e9lder Costa (Wolverhampton Wanderers) left footed shot from outside the box is saved in the bottom left corner. Assisted by Danny Batth.\nCorner,  Wolverhampton Wanderers. Conceded by Jiri Skalak.\nCorner,  Wolverhampton Wanderers. Conceded by Glenn Murray.\nCorner,  Wolverhampton Wanderers. Conceded by David Stockdale.\nAttempt saved. Danny Batth (Wolverhampton Wanderers) right footed shot from outside the box is saved in the bottom left corner.\nDanny Batth (Wolverhampton Wanderers) wins a free kick in the defensive half.\nFoul by Glenn Murray (Brighton and Hove Albion).\nAttempt saved. Romain Saiss (Wolverhampton Wanderers) left footed shot from outside the box is saved in the bottom left corner.\nSubstitution, Brighton and Hove Albion. S\u00e9bastien Pocognoli replaces Anthony Knockaert.\nCorner,  Wolverhampton Wanderers. Conceded by Steve Sidwell.\nHand ball by Anthony Knockaert (Brighton and Hove Albion).\nJ\u00f3n Dadi B\u00f6dvarsson (Wolverhampton Wanderers) wins a free kick in the attacking half.\nFoul by Oliver Norwood (Brighton and Hove Albion).\nFoul by Romain Saiss (Wolverhampton Wanderers).\nConnor Goldson (Brighton and Hove Albion) wins a free kick on the right wing.\nAttempt saved. Anthony Knockaert (Brighton and Hove Albion) right footed shot from the left side of the box is saved in the bottom left corner. Assisted by Jiri Skalak.\nCorner,  Brighton and Hove Albion. Conceded by Danny Batth.\nSubstitution, Brighton and Hove Albion. Dale Stephens replaces Sam Baldock.\nFoul by Ivan Cavaleiro (Wolverhampton Wanderers).\nJiri Skalak (Brighton and Hove Albion) wins a free kick in the defensive half.\nH\u00e9lder Costa (Wolverhampton Wanderers) wins a free kick on the left wing.\nFoul by Connor Goldson (Brighton and Hove Albion).\nSubstitution, Brighton and Hove Albion. Connor Goldson replaces Bruno because of an injury.\nOffside, Wolverhampton Wanderers. Romain Saiss tries a through ball, but Ivan Cavaleiro is caught offside.\nAttempt missed. Romain Saiss (Wolverhampton Wanderers) left footed shot from outside the box is high and wide to the left. Assisted by Ivan Cavaleiro.\nAttempt missed. Anthony Knockaert (Brighton and Hove Albion) left footed shot from the centre of the box misses to the left. Assisted by Bruno with a cross.\nFoul by Romain Saiss (Wolverhampton Wanderers).\nSam Baldock (Brighton and Hove Albion) wins a free kick in the defensive half.\nJ\u00f3n Dadi B\u00f6dvarsson (Wolverhampton Wanderers) wins a free kick in the defensive half.\nFoul by Steve Sidwell (Brighton and Hove Albion).\nFoul by David Edwards (Wolverhampton Wanderers).\nSteve Sidwell (Brighton and Hove Albion) wins a free kick in the defensive half.\nSubstitution, Wolverhampton Wanderers. Jo\u00e3o Teixeira replaces Nouha Dicko.",
+    "reference": "Sam Baldock's first-half header proved enough to give in-form Brighton a home victory over Wolverhampton Wanderers.",
+    "prediction": "Sam Baldock scored the only goal of the game as Brighton beat Wolves to move up to fourth in the Championship.",
+    "entities": [
+      {
+        "ent": "fourth",
+        "type": "ORDINAL",
+        "start": 83,
+        "end": 89,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.06982696801424026,
+        "posterior_prob": 0.20073343813419342
+      }
+    ]
+  },
+  {
+    "source": "The US economy grew at an annual rate of 0.2% in the first three months of the year, far lower than forecasts.\nThe Federal Reserve also kept interest rates at a record low, blaming the slower growth on \"transitory factors\".\nJapan's Nikkei 225 was down 2.7% to 19,520.21, its biggest loss in nearly four months.\nThe market extended losses after Bank of Japan left its monetary policy unchanged, while lacklustre company earnings also had their impact on the benchmark index.\nShares in Honda fell 6.7% after it announced a fall in profit for the fiscal year to March, as it deals with recalls following exploding air-bags.\nDrug maker Takeda shares fell 3% after it warned it would make a loss because of a $2.4bn US legal settlement linked to its Actos diabetes drug.\nChinese shares headed lower with Hong Kong's Hang Seng index falling 0.9% to 28,157.71, while the Shanghai Composite was 0.6% lower at 4,449.17.\nShares of AAC Technologies in Hong Kong fell 5.2% after a report in the Wall Street Journal that the Apple Watch had defective component, which was supplied by the Chinese company.\nIn Australia, the benchmark S&P/ASX 200 ended down 0.8% at 5,790.\nSouth Korea's benchmark Kospi index closed down 0.7% at 2,127.17 - marking its fifth consecutive day of losses.\nGovernment data showed that the country's industrial output fell by a seasonally adjusted 0.4% in March from February - missing market expectations.",
+    "reference": "Asian markets traded lower on Thursday with investor sentiment dented by a weaker than expected first quarter growth figure in the US.",
+    "prediction": "Asian shares headed lower on Thursday after the US economy grew at its slowest pace in more than three years.",
+    "entities": [
+      {
+        "ent": "Thursday",
+        "type": "DATE",
+        "start": 29,
+        "end": 37,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.16323554515838623,
+        "posterior_prob": 0.2164635956287384
+      },
+      {
+        "ent": "more than three years",
+        "type": "DATE",
+        "start": 87,
+        "end": 108,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 8.08442200650461e-06,
+        "posterior_prob": 0.022917797788977623
+      }
+    ]
+  },
+  {
+    "source": "The US economy grew at an annual rate of 0.2% in the first three months of the year, far lower than forecasts.\nThe Federal Reserve also kept interest rates at a record low, blaming the slower growth on \"transitory factors\".\nJapan's Nikkei 225 was down 2.7% to 19,520.21, its biggest loss in nearly four months.\nThe market extended losses after Bank of Japan left its monetary policy unchanged, while lacklustre company earnings also had their impact on the benchmark index.\nShares in Honda fell 6.7% after it announced a fall in profit for the fiscal year to March, as it deals with recalls following exploding air-bags.\nDrug maker Takeda shares fell 3% after it warned it would make a loss because of a $2.4bn US legal settlement linked to its Actos diabetes drug.\nChinese shares headed lower with Hong Kong's Hang Seng index falling 0.9% to 28,157.71, while the Shanghai Composite was 0.6% lower at 4,449.17.\nShares of AAC Technologies in Hong Kong fell 5.2% after a report in the Wall Street Journal that the Apple Watch had defective component, which was supplied by the Chinese company.\nIn Australia, the benchmark S&P/ASX 200 ended down 0.8% at 5,790.\nSouth Korea's benchmark Kospi index closed down 0.7% at 2,127.17 - marking its fifth consecutive day of losses.\nGovernment data showed that the country's industrial output fell by a seasonally adjusted 0.4% in March from February - missing market expectations.",
+    "reference": "Asian markets traded lower on Thursday with investor sentiment dented by a weaker than expected first quarter growth figure in the US.",
+    "prediction": "Chinese shares headed lower on Friday, following Wall Street lower after the latest US economic growth figures.",
+    "entities": [
+      {
+        "ent": "Friday",
+        "type": "DATE",
+        "start": 31,
+        "end": 37,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.07438555359840393,
+        "posterior_prob": 0.07983403652906418
+      }
+    ]
+  },
+  {
+    "source": "The US economy grew at an annual rate of 0.2% in the first three months of the year, far lower than forecasts.\nThe Federal Reserve also kept interest rates at a record low, blaming the slower growth on \"transitory factors\".\nJapan's Nikkei 225 was down 2.7% to 19,520.21, its biggest loss in nearly four months.\nThe market extended losses after Bank of Japan left its monetary policy unchanged, while lacklustre company earnings also had their impact on the benchmark index.\nShares in Honda fell 6.7% after it announced a fall in profit for the fiscal year to March, as it deals with recalls following exploding air-bags.\nDrug maker Takeda shares fell 3% after it warned it would make a loss because of a $2.4bn US legal settlement linked to its Actos diabetes drug.\nChinese shares headed lower with Hong Kong's Hang Seng index falling 0.9% to 28,157.71, while the Shanghai Composite was 0.6% lower at 4,449.17.\nShares of AAC Technologies in Hong Kong fell 5.2% after a report in the Wall Street Journal that the Apple Watch had defective component, which was supplied by the Chinese company.\nIn Australia, the benchmark S&P/ASX 200 ended down 0.8% at 5,790.\nSouth Korea's benchmark Kospi index closed down 0.7% at 2,127.17 - marking its fifth consecutive day of losses.\nGovernment data showed that the country's industrial output fell by a seasonally adjusted 0.4% in March from February - missing market expectations.",
+    "reference": "Asian markets traded lower on Thursday with investor sentiment dented by a weaker than expected first quarter growth figure in the US.",
+    "prediction": "(Close): Shares in Japan and China fell sharply on Wednesday, as investors weighed down by disappointing US economic growth data.",
+    "entities": [
+      {
+        "ent": "China",
+        "type": "GPE",
+        "start": 29,
+        "end": 34,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.060700785368680954,
+        "posterior_prob": 0.7940036654472351
+      }
+    ]
+  },
+  {
+    "source": "The water pipes in the town are old and prone to leaks and bursts, Severn Trent Water said.\nPart of Milford Road is expected to be closed until the summer as a metal water pipe is replaced. Diversions will be in place.\nThe road is \"just too narrow\" in parts to be kept open as large machinery will be used, a spokesman said.\nMore than 12 miles (20km) of new water pipes are being laid from the Shugborough area into Stafford town centre.\nIn the first phase, which began in September, pipes were installed on Tixall Road for a new housing development nearby.",
+    "reference": "The second phase of a \u00a315m project to upgrade the water and sewer pipes in Stafford is under way.",
+    "prediction": "A road in Stafford town centre is to be closed as part of a \u00a31m project to replace water pipes.",
+    "entities": [
+      {
+        "ent": "\u00a31m",
+        "type": "MONEY",
+        "start": 60,
+        "end": 63,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.021565673872828484,
+        "posterior_prob": 2.4012859284994192e-05
+      }
+    ]
+  },
+  {
+    "source": "The Vikings led the table after winning six of their first seven games but slipped from the top after losing to Warrington on 25 March.\nBetts' side currently lie in fifth place in the table and face league leaders Warrington again on Friday.\n\"I don't see our form being that bad, we've just lost some games,\" Betts told BBC Radio Merseyside.\n\"We've lost some momentum to look at the table, but internally we're still doing some good things.\"\nAfter conceding 108 points in their opening seven matches, Widnes' fortunes have changed of late, with the Vikings conceding 103 points in their last four games.\n\"It's about doing the little things well, keeping the confidence high and doing the things we did at the beginning of the year with the same kind of determination,\" he added.\n\"We know we've got to get moving back in the league but Warrington are saying the same thing and there are guys who are fighting to get some momentum in their league positions.\"",
+    "reference": "Head coach Denis Betts is not worried about Widnes' recent form despite four consecutive Super League defeats.",
+    "prediction": "Widnes Vikings head coach Ian Betts says his side have not lost momentum despite their recent poor form in Super League.",
+    "entities": [
+      {
+        "ent": "Widnes Vikings",
+        "type": "ORG",
+        "start": 0,
+        "end": 14,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 1.416869512527055e-21,
+        "posterior_prob": 7.390051434295539e-14
+      },
+      {
+        "ent": "Ian",
+        "type": "PERSON",
+        "start": 26,
+        "end": 29,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.025279482826590538,
+        "posterior_prob": 0.004628239665180445
+      }
+    ]
+  },
+  {
+    "source": "The Vikings led the table after winning six of their first seven games but slipped from the top after losing to Warrington on 25 March.\nBetts' side currently lie in fifth place in the table and face league leaders Warrington again on Friday.\n\"I don't see our form being that bad, we've just lost some games,\" Betts told BBC Radio Merseyside.\n\"We've lost some momentum to look at the table, but internally we're still doing some good things.\"\nAfter conceding 108 points in their opening seven matches, Widnes' fortunes have changed of late, with the Vikings conceding 103 points in their last four games.\n\"It's about doing the little things well, keeping the confidence high and doing the things we did at the beginning of the year with the same kind of determination,\" he added.\n\"We know we've got to get moving back in the league but Warrington are saying the same thing and there are guys who are fighting to get some momentum in their league positions.\"",
+    "reference": "Head coach Denis Betts is not worried about Widnes' recent form despite four consecutive Super League defeats.",
+    "prediction": "Widnes Vikings head coach Paul Betts says his side have not lost momentum in Super League despite their recent poor form.",
+    "entities": [
+      {
+        "ent": "Paul",
+        "type": "PERSON",
+        "start": 26,
+        "end": 30,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.11673146486282349,
+        "posterior_prob": 0.027021804824471474
+      }
+    ]
+  },
+  {
+    "source": "The Vikings led the table after winning six of their first seven games but slipped from the top after losing to Warrington on 25 March.\nBetts' side currently lie in fifth place in the table and face league leaders Warrington again on Friday.\n\"I don't see our form being that bad, we've just lost some games,\" Betts told BBC Radio Merseyside.\n\"We've lost some momentum to look at the table, but internally we're still doing some good things.\"\nAfter conceding 108 points in their opening seven matches, Widnes' fortunes have changed of late, with the Vikings conceding 103 points in their last four games.\n\"It's about doing the little things well, keeping the confidence high and doing the things we did at the beginning of the year with the same kind of determination,\" he added.\n\"We know we've got to get moving back in the league but Warrington are saying the same thing and there are guys who are fighting to get some momentum in their league positions.\"",
+    "reference": "Head coach Denis Betts is not worried about Widnes' recent form despite four consecutive Super League defeats.",
+    "prediction": "Widnes Vikings head coach Justin Betts says his side have not lost momentum despite their recent poor form in Super League.",
+    "entities": [
+      {
+        "ent": "Justin",
+        "type": "PERSON",
+        "start": 26,
+        "end": 32,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0045407903380692005,
+        "posterior_prob": 0.02823595143854618
+      }
+    ]
+  },
+  {
+    "source": "Leonie Granger from Gillingham, Kent, was sentenced at the Old Bailey having been found guilty of manslaughter.\nHer boyfriend Kyrron Jackson, 28, and his friend Nicholas Chandler, 29, were found guilty of murder and jailed for life with a minimum term of 36 years.\nGranger targeted Mehmet Hassan, 56, in a Mayfair casino in March last year.\nJudge William Kennedy described the attack as \"pitiless and wicked\", adding: \"It was quite simply an act of brutality which defies reason and compassion.\"\nGranger's lawyer Orlando Pownall said she only took part in the plot as she was in love with Jackson and \"fell in with his desires\" and now \"deeply regretted\" her actions.\n\"Her head was turned by Jackson, who she loved, and to some extent by Chandler who was persuasive and superficially charming,\" he said.\nBut Judge Kennedy said she had been \"deceitful from the outset\" and had \"lost her sense and compassion\" when she got involved.\nHe added that she clearly cared more for Jackson than he cared for her.\nGranger, who posed under the name of Rachel, was wined and dined by the divorced father of three who boasted to friends he was not paying her to be with him, the court heard earlier.\nOn the night he was killed, Mr Hassan had taken Granger to the upmarket Nobu restaurant before giving her \u00c2\u00a31,000 to gamble with at the nearby Palm Beach Casino.\nThe two were seen kissing passionately by a poker supervisor, before leaving the casino together for Mr Hassan's flat in Islington.\nGranger then let Jackson and Chandler into the poker player's flat before leaving in a taxi.\nBoth men tied up Mr Hassan with parcel tape and a neck tie before kicking and stamping him to death, the trial was told.\nAfterwards, while he lay dead in a pool of blood, all three were filmed on Granger's mobile phone throwing \u00c2\u00a350 notes around a room and even stuffing  them in their underpants.\nCommenting on the footage, Judge Kennedy told the three defendants: \"The eloquence with which it speaks about you is deafening.\"",
+    "reference": "A woman who set a \"honey trap\" for a professional gambler who was kicked to death for his winnings has been jailed for 16 years.",
+    "prediction": "A 23-year-old woman who admitted killing a poker player in a \"pitiless and wicked\" attack has been jailed for 20 years.",
+    "entities": [
+      {
+        "ent": "23-year-old",
+        "type": "DATE",
+        "start": 2,
+        "end": 13,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0020261919125914574,
+        "posterior_prob": 0.00191772251855582
+      }
+    ]
+  },
+  {
+    "source": "The 51-year-old London mayor has spent more than a decade combining the gravitas of his various roles with an unkempt, humorous persona rarely seen in modern public life.\nPrime Minister David Cameron expressed his delight when Mr Johnson announced his decision to run for parliament again in 2015, saying: \"I want my star players on the pitch.\"\nBut now the MP for Uxbridge and South Ruislip has said he will campaign against the PM in the EU referendum, relations between the two may become more tense.\nThe big question is whether the blond-haired old Etonian wants simply to play for the team or to captain it.\nHe has arguably the highest profile of any Conservative except Mr Cameron and is thought by many to harbour an ambition to be prime minister.\nWhen he beat Labour's Ken Livingstone to become London mayor in 2008 it was the Tories' first high-profile election success since before Tony Blair's triumphant entry into Downing Street in 1997. He defeated Mr Livingstone again in 2012, giving him even more of a winner's aura.\nThe hoopla surrounding Mr Johnson broke out again when he ended months of speculation by confirming he would try to return to the Commons as MP for Uxbridge and South Ruislip.\nHe swept into the safe Conservative London seat in the 2015 general election, taking a spot at the cabinet table as minister without portfolio.\nGiven the opportunity to enter Downing Street on a fortnightly basis, cycle helmet in hand, was seen as recognition for his unique rapport with voters.\nBut crucially he is not bound by collective cabinet responsibility, giving him the freedom to rebel against controversial decisions without having to resign.\nAlthough lauded by Conservative activists for his witty speeches, Euroscepticism and lack of PR polish, Mr Johnson's political life has not been blemish-free.\nIn 2004 he had to make a visit to Liverpool to apologise for an article in the Spectator magazine, which he then edited. It had criticised the people of the city for their reaction to the death of Ken Bigley, the British contractor taken hostage and killed in Iraq.\nThe following month he was sacked by Conservative leader Michael Howard for failing to tell the party the truth about claims he had an affair.\nHe created media hysteria at the 2006 Conservative Party conference when he attacked healthy eating advice advocated by the chef Jamie Oliver. He said he would like to \"get rid of [him] and tell people to eat what they like\".\nLater he provoked anger by describing Portsmouth as \"too full of drugs, obesity, underachievement and Labour MPs\" and associating Papua New Guinea \"with orgies of cannibalism and chief-killing\".\nThe London mayor's life has been as exotic as his use of language.\nAlexander Boris de Pfeffel Johnson was born in New York and he held US citizenship until 2006. Descended from Turkish, French and German stock he describes himself as a \"one-man melting pot\". His great-grandfather, Ali Kemal, briefly served as an interior minister in the Ottoman Empire.\nThe son of a diplomat and Conservative Member of the European Parliament, he was educated at Eton College, where he was senior to Mr Cameron. There is said to be a sense of resentment on Mr Johnson's part at being overtaken by his younger rival.\nAt Oxford University, Mr Johnson, who flirted briefly with the centre-left Social Democratic Party, was President of the Union. After only a week as a trainee management consultant he moved to journalism. Fired from the Times for making up a quote, he then worked for the Wolverhampton Express and Star before joining the Daily Telegraph, working as its Brussels correspondent and assistant editor.\nIn his seven years as MP for the ultra-safe Conservative seat of Henley from 2001 he did not make the shadow cabinet, becoming a party vice-chairman and holding roles as a junior spokesman on education and culture.\nHis decision to run for London mayor in 2008 added excitement to the contest. However, during the campaign he made a conscious effort to avoid giving reason for accusations of eccentricity. Most Londoners seemed to approve, as he beat Mr Livingstone by 54% to 47%.\nDays after his victory he banned alcohol consumption on public transport. A keen cyclist himself, he launched a central London bicycle hire scheme, known colloquially as \"Boris bikes\", and ditched the \"bendy bus\" in favour of a new generation of double-deckers.\nAlthough suffering a series of high-profile resignations from City Hall, it was Sir Ian Blair's departure as the Metropolitan Police Commissioner which attracted most controversy. Sir Ian said he was stepping down because of a lack of support from Mr Johnson.\nHe was in charge when riots hit the capital in the summer of 2011. Initially criticised for taking too long to return from a holiday, he was later praised for his handling of events, including making tours of the affected areas.\nMr Johnson also represented the city when it received its greatest publicity in decades, during the 2012 Olympics. His speeches were well received but he was a little embarrassed when, at one promotional event, he became caught on a zipwire, to the delight of photographers.\nIn 2011 he told the BBC's Newsnight he did not expect to do \"another big job in politics\" after leaving the mayoralty. This was not universally accepted at face value.\nMr Johnson has arguably fuelled speculation about his ambitions by continuing to make speeches touching on issues beyond his remit in London, in particular on Europe.\nHis latest decision means that speculation is guaranteed to continue.",
+    "reference": "Boris Johnson's decision to campaign for Britain to leave the EU is being regarded as a huge boost for the Out campaign.",
+    "prediction": "Boris Johnson is one of the UK's most colourful and controversial politicians.",
+    "entities": [
+      {
+        "ent": "UK",
+        "type": "GPE",
+        "start": 28,
+        "end": 30,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.127445250749588,
+        "posterior_prob": 0.903255045413971
+      }
+    ]
+  },
+  {
+    "source": "The news had been expected after the Cobblers' new owner Kelvin Thomas paid HM Revenue & Customs unpaid tax it was due when he bought the club last week.\n\"This is a very positive step as we move forward,\" said Thomas.\n\"We can now focus on our review of the club and developing the future plans.\"\nOn Friday, the Cobblers' administration petition brought by Northampton Borough Council was adjourned to 11 December for a deal to be made between Thomas and the council.\nThomas purchased the club from David Cardoza on Thursday and became executive chairman of the Cobblers.\nThomas and the council have a memorandum of understanding in place over a \u00a310.25m loan to the club for redevelopment work at Sixfields Stadium, which would would see the debt wiped out, with the council acquiring land near Sixfields for development in return.\nDespite the uncertainty off the pitch, the Cobblers are currently in the League Two automatic promotion places.",
+    "reference": "The winding-up petition brought against League Two side Northampton Town has been withdrawn following a court hearing on Monday.",
+    "prediction": "League Two side Northampton Town have been placed into administration.",
+    "entities": [
+      {
+        "ent": "Northampton Town",
+        "type": "GPE",
+        "start": 16,
+        "end": 32,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.008270631544291973,
+        "posterior_prob": 0.8459948897361755
+      }
+    ]
+  },
+  {
+    "source": "Dead Men Risen, written by Toby Harnden and published by Quercus, took the prize at a ceremony in Westminster and was the judges' unanimous choice.\nIt focuses on the death of Lt Colonel Rupert Thorneloe in 2009.\nIt was published in amended form after the first print run was destroyed by the MoD.\nThe judges said the book \"takes us into the hearts and minds of the Welsh Guards in a way that is both interesting and visceral\".\n\"It challenges every citizen of this country to examine exactly what we're asking soldiers to do in Afghanistan,\" the panel continued.\n\"Rather than offering easy answers it lets the soldiers speak for themselves.\"\nOther awards presented included a posthumous honour for Christopher Hitchens, whose final book, Arguably, was included on the long list for the top prize.\nHitchens' widow Carol Blue accepted the award on behalf of the Vanity Fair writer.\nThe journalism prize was awarded to Amelia Gentleman for her work in The Guardian, while the blog award went to Rangers Tax Case - an online commentary on the ongoing financial problems at the historic Scottish football club.\nThe writers of the blog said they aimed to \"provide the details of what Rangers FC have done, why it was illegal and what the implications are for one of the largest football clubs in Britain\".\nThe winners were chosen from shortlists of six books, six journalists and seven bloggers, whittled down from longlists of 17 books, 12 journalists and 18 bloggers.\nEach of the winners received a \u00c2\u00a33,000 prize.",
+    "reference": "A book about the death of a British officer in Afghanistan, once pulped by the Ministry of Defence, has won the Orwell Prize for political writing.",
+    "prediction": "A book about the death of a Welsh Guards soldier in Afghanistan has won the Man Booker Prize.",
+    "entities": [
+      {
+        "ent": "the Man Booker Prize",
+        "type": "WORK_OF_ART",
+        "start": 72,
+        "end": 92,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.00012038826389471069,
+        "posterior_prob": 0.02943035028874874
+      }
+    ]
+  },
+  {
+    "source": "Andrew Hutchinson, from Abingdon, Oxfordshire, pleaded guilty to rape, sexual assault and voyeurism committed from 2011 to 2013.\nThe 29-year-old filmed himself raping two patients at the John Radcliffe Hospital in Oxford, where he worked.\nHe also attacked women who had passed out while he was on duty at a music festival, Oxford Crown Court heard.\nHutchinson targeted women who had lost consciousness through drinking too much and they were unaware they had been assaulted until contacted by Thames Valley Police.\nThe court heard the women he raped in the A&E department at the Oxford hospital had to view parts of Hutchinson's recordings in order to identify themselves.\nOne victim, an 18-year-old, was raped in October 2011 and a 35-year-old was raped in February 2012.\nHe also attacked two women in their 20s while volunteering as a medic at the Wilderness Festival in Cornbury Park, Oxfordshire, in August 2013.\nHis was tending the women when he committed the crimes, one in a medical tent and the other in a nearby ambulance.\nOfficers initially arrested him for secretly filming girls as young as nine in changing rooms at the White Horse Leisure Centre in Abingdon in November 2013.\nFollowing a search of his home, police found footage of sex attacks on his computer and mobile phone.\nThe court was told Hutchinson also had hundreds of other voyeuristic images, including \"up skirt\" pictures taken on the London Underground while he was  volunteering at the 2012 Olympics.\nVictims were also filmed at John Radcliffe Hospital and at a gym in Batley, West Yorkshire where he had previously worked.\nAt a hearing on 30 March, he also pleaded guilty to outraging public decency, making indecent images of children, theft of a hospital camera used for internal examinations and possession of the class B drug ketamine.\nThe victims of his crimes were aged between nine and 35, although many were unidentifiable due to the nature of the footage.\nCatherine Stoddart, chief nurse at Oxford University Hospitals NHS Trust, said: \"I am shocked and horrified by the way in which Andrew Hutchinson has betrayed the patients he was entrusted to care for and his colleagues, who also trusted him.\"\nShe said the hospital will be carrying out an internal review to see if Hutchinson could have been prevented from committing his crimes.\nHutchinson was suspended by the trust in November 2013 following allegations he stole medical equipment.\nIt also informed the Nursing and Midwifery Council and launched an internal investigation, which led to his dismissal.\nJudge Ian Pringle QC described Hutchinson's crimes as \"despicable\".\nHe said: \"When they were unconscious requiring your help and your assistance as their nurse, you raped them and you filmed it.\n\"It is impossible to conceive of a greater breach of trust in our society.\"\nIn a statement read out in court, one of the victims said: \"I think that what he has done is much worse that doing it in the street because I had no idea what was happening, so I had no opportunity to fight back.\"\nSenior investigating officer, Det Ch Insp Mark Johns of Thames Valley Police, said: \"This has been a particularly complicated, unusual and sensitive case as the victims were not aware that offences took place because they were not conscious.\n\"I would like to thank the victims for the great courage and dignity they have shown during our investigation.\"\nPolice said all victims who can be identified have been contacted.\nAnyone with concerns can contact police on 101, quoting Operation Bream.",
+    "reference": "A former nurse has been jailed for 18 years for raping and sexually assaulting unconscious women.",
+    "prediction": "A nurse who secretly filmed himself raping patients has been jailed for eight years.",
+    "entities": [
+      {
+        "ent": "eight years",
+        "type": "DATE",
+        "start": 72,
+        "end": 83,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.001804435858502984,
+        "posterior_prob": 0.07268925756216049
+      }
+    ]
+  },
+  {
+    "source": "Andrew Hutchinson, from Abingdon, Oxfordshire, pleaded guilty to rape, sexual assault and voyeurism committed from 2011 to 2013.\nThe 29-year-old filmed himself raping two patients at the John Radcliffe Hospital in Oxford, where he worked.\nHe also attacked women who had passed out while he was on duty at a music festival, Oxford Crown Court heard.\nHutchinson targeted women who had lost consciousness through drinking too much and they were unaware they had been assaulted until contacted by Thames Valley Police.\nThe court heard the women he raped in the A&E department at the Oxford hospital had to view parts of Hutchinson's recordings in order to identify themselves.\nOne victim, an 18-year-old, was raped in October 2011 and a 35-year-old was raped in February 2012.\nHe also attacked two women in their 20s while volunteering as a medic at the Wilderness Festival in Cornbury Park, Oxfordshire, in August 2013.\nHis was tending the women when he committed the crimes, one in a medical tent and the other in a nearby ambulance.\nOfficers initially arrested him for secretly filming girls as young as nine in changing rooms at the White Horse Leisure Centre in Abingdon in November 2013.\nFollowing a search of his home, police found footage of sex attacks on his computer and mobile phone.\nThe court was told Hutchinson also had hundreds of other voyeuristic images, including \"up skirt\" pictures taken on the London Underground while he was  volunteering at the 2012 Olympics.\nVictims were also filmed at John Radcliffe Hospital and at a gym in Batley, West Yorkshire where he had previously worked.\nAt a hearing on 30 March, he also pleaded guilty to outraging public decency, making indecent images of children, theft of a hospital camera used for internal examinations and possession of the class B drug ketamine.\nThe victims of his crimes were aged between nine and 35, although many were unidentifiable due to the nature of the footage.\nCatherine Stoddart, chief nurse at Oxford University Hospitals NHS Trust, said: \"I am shocked and horrified by the way in which Andrew Hutchinson has betrayed the patients he was entrusted to care for and his colleagues, who also trusted him.\"\nShe said the hospital will be carrying out an internal review to see if Hutchinson could have been prevented from committing his crimes.\nHutchinson was suspended by the trust in November 2013 following allegations he stole medical equipment.\nIt also informed the Nursing and Midwifery Council and launched an internal investigation, which led to his dismissal.\nJudge Ian Pringle QC described Hutchinson's crimes as \"despicable\".\nHe said: \"When they were unconscious requiring your help and your assistance as their nurse, you raped them and you filmed it.\n\"It is impossible to conceive of a greater breach of trust in our society.\"\nIn a statement read out in court, one of the victims said: \"I think that what he has done is much worse that doing it in the street because I had no idea what was happening, so I had no opportunity to fight back.\"\nSenior investigating officer, Det Ch Insp Mark Johns of Thames Valley Police, said: \"This has been a particularly complicated, unusual and sensitive case as the victims were not aware that offences took place because they were not conscious.\n\"I would like to thank the victims for the great courage and dignity they have shown during our investigation.\"\nPolice said all victims who can be identified have been contacted.\nAnyone with concerns can contact police on 101, quoting Operation Bream.",
+    "reference": "A former nurse has been jailed for 18 years for raping and sexually assaulting unconscious women.",
+    "prediction": "A nurse who secretly filmed himself raping patients has been jailed for seven years.",
+    "entities": [
+      {
+        "ent": "seven years",
+        "type": "DATE",
+        "start": 72,
+        "end": 83,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.000972002511844039,
+        "posterior_prob": 0.09223319590091705
+      }
+    ]
+  },
+  {
+    "source": "Four average 50mph enforcement cameras were installed in October on a two-mile stretch at Port Talbot and they went live on Monday.\nBut around 125-a-day have been caught in less than a week.\nThe cameras are the first to go into operation on a Welsh section of the M4, and during a pilot before Christmas around 700 drivers a day were caught.\nHowever, Wales Road Casualty Reduction Partnership GoSafe welcomed the reduction in drivers caught compared with the trial period.\nPartnership manager Chris Hume said: \"There is a clear indication that there has been a decrease in the numbers of people exceeding the limit.\n\"Excessive and inappropriate speed remains a factor in collisions and associated fatalities and serious injuries on our roads in Wales.\n\"Our main priority is to continue to educate motorists about the effect of inappropriate speed with enforcement being the last resort after engineering solutions are considered.\"",
+    "reference": "More than 500 speeding drivers have been caught by new cameras on the M4 in just five days.",
+    "prediction": "The number of drivers caught speeding on the M4 in south Wales has fallen by more than a third since cameras were installed.",
+    "entities": [
+      {
+        "ent": "south Wales",
+        "type": "GPE",
+        "start": 51,
+        "end": 62,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.0011624660110101104,
+        "posterior_prob": 2.083108847727999e-05
+      }
+    ]
+  },
+  {
+    "source": "The members say they'll continue as a four-piece after Zayn Malik announced he was leaving the group last week to \"live like a normal 22-year-old\".\nHis departure was followed by rumours on Twitter, Instagram and Facebook that One Direction was about to break up.\nBut Liam Payne thanked fans for sticking with the band and for \"not thinking it's finished\".\nHe tweeted: \"I can see a lot of people thanking us for staying but your the real Heros here thanks for not thinking it's finished.\"\nThe band continued their On the Road Again tour and have been playing concerts in South Africa.\nThey start the European leg of the tour by playing Cardiff's Millennium Stadium on 5 and 6 June.\nZayn Malik quit the group last week after flying back to the UK, having been \"signed off with stress\".\nIt was after reports that he'd cheated on his 21-year-old fiancee, Perrie Edwards.\nHe told The Sun that he was \"upset\" for the group's fans and he said there was no bad blood between him and his former bandmates, who he said had been \"really supportive\".\nIt's thought he's working on a solo album with producer Naughty Boy, who's worked on tracks for Emeli Sande, Cheryl Cole and Leona Lewis.\nFollow @BBCNewsbeat on Twitter, BBCNewsbeat on Instagram and Radio1Newsbeat on YouTube",
+    "reference": "One Direction is not on the verge of splitting up, despite rumours started on social media.",
+    "prediction": "Liam Payne and Niall Horan have confirmed they're staying in One Direction.",
+    "entities": [
+      {
+        "ent": "Niall",
+        "type": "PERSON",
+        "start": 15,
+        "end": 20,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.9644831418991089,
+        "posterior_prob": 0.8258779048919678
+      },
+      {
+        "ent": "Horan",
+        "type": "PERSON",
+        "start": 21,
+        "end": 26,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.9995003938674927,
+        "posterior_prob": 0.04673899710178375
+      }
+    ]
+  },
+  {
+    "source": "The members say they'll continue as a four-piece after Zayn Malik announced he was leaving the group last week to \"live like a normal 22-year-old\".\nHis departure was followed by rumours on Twitter, Instagram and Facebook that One Direction was about to break up.\nBut Liam Payne thanked fans for sticking with the band and for \"not thinking it's finished\".\nHe tweeted: \"I can see a lot of people thanking us for staying but your the real Heros here thanks for not thinking it's finished.\"\nThe band continued their On the Road Again tour and have been playing concerts in South Africa.\nThey start the European leg of the tour by playing Cardiff's Millennium Stadium on 5 and 6 June.\nZayn Malik quit the group last week after flying back to the UK, having been \"signed off with stress\".\nIt was after reports that he'd cheated on his 21-year-old fiancee, Perrie Edwards.\nHe told The Sun that he was \"upset\" for the group's fans and he said there was no bad blood between him and his former bandmates, who he said had been \"really supportive\".\nIt's thought he's working on a solo album with producer Naughty Boy, who's worked on tracks for Emeli Sande, Cheryl Cole and Leona Lewis.\nFollow @BBCNewsbeat on Twitter, BBCNewsbeat on Instagram and Radio1Newsbeat on YouTube",
+    "reference": "One Direction is not on the verge of splitting up, despite rumours started on social media.",
+    "prediction": "Liam Payne and Louis Tomlinson have confirmed they're staying in One Direction.",
+    "entities": [
+      {
+        "ent": "Louis",
+        "type": "PERSON",
+        "start": 15,
+        "end": 20,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.7288460731506348,
+        "posterior_prob": 0.6384851336479187
+      },
+      {
+        "ent": "Tomlinson",
+        "type": "PERSON",
+        "start": 21,
+        "end": 30,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.982655942440033,
+        "posterior_prob": 0.05037503316998482
+      }
+    ]
+  },
+  {
+    "source": "The move apparently follows a request from Prime Minister Benjamin Netanyahu's office.\nIt also comes ahead of a speech on the Israeli-Palestinian conflict by US Secretary of State John Kerry.\nOn Friday, the US chose not to veto a UN Security Council resolution calling for an end to settlement construction.\nThe decision to abstain infuriated Mr Netanyahu, whose spokesman said on Tuesday he had \"ironclad information\" from Arab sources that the White House had helped draft the language of the resolution and \"pushed hard\" for its passage.\nA US state department spokesman said the accusation was \"just not true\", but he hoped the resolution would \"serve as a wake-up call\" for Israel.\nMore than 500,000 Jews live in about 140 settlements built since Israel's 1967 occupation of the West Bank and East Jerusalem. The settlements are considered illegal under international law, though Israel disputes this.\nThe Security Council resolution passed on Friday stated that the establishment of settlements \"has no legal validity and constitutes a flagrant violation under international law and a major obstacle to the achievement of the two-state solution and a just, lasting and comprehensive peace\".\nIsrael rejected the resolution, and the BBC's Yolande Knell said it was particularly angry about the condemnation of building in East Jerusalem - which it sees as part of its capital, but which the Palestinians want as the capital of their future state.\nMr Netanyahu responded over the weekend by summoning the ambassadors of the US and the 14 countries on the Security Council who voted in favour of the resolution, recalling Israel's ambassadors to New Zealand and Senegal, cutting aid to Senegal, and cancelling a visit by Ukraine's prime minister.\nThe Jerusalem Planning and Housing Committee had indicated it would press ahead with a planned vote on authorising 492 new homes in the settlements of Ramat Shlomo and Ramot.\nBut on Wednesday, planning committee member Hanan Rubin said the vote had been postponed.\nMr Rubin told the BBC this was at the request of the prime minister's office, to avoid further straining relations with Washington hours before Mr Kerry's speech.\n\"It's in our interest to avoid political voting in Jerusalem because Jerusalem is not the same as settlements around Israel,\" he said.\n\"We are creating affordable housing and housing for young families... and if there is a big storm and Kerry's speech today, we are looking to avoid this conflict.\"\nMr Kerry is expected to lay out his vision later on Wednesday for ending the Israel-Palestinian conflict, and address what a senior state department official described as \"misleading critiques\" of the Obama administration by the Israeli government.\nPalestinian Authority President Mahmoud Abbas has said the resolution \"paves the way\" for the upcoming conference on Middle East peace in France on 15 January.\n\"We hope this conference comes up with a mechanism and timetable to end the occupation,\" he told a meeting of his Fatah party on Monday.",
+    "reference": "An Israeli committee has postponed a vote to authorise construction of almost 500 new homes in Jewish settlements in occupied East Jerusalem.",
+    "prediction": "Israel's Jerusalem planning committee has postponed a vote on approving hundreds of new homes in settlements in the occupied West Bank.",
+    "entities": [
+      {
+        "ent": "Jerusalem planning committee",
+        "type": "ORG",
+        "start": 9,
+        "end": 37,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 9.63439106271835e-07,
+        "posterior_prob": 0.005798995960503817
+      }
+    ]
+  },
+  {
+    "source": "The victim claims no-one responded when he brought the alleged offences to light.\nA complaint is being reviewed by the Church of England, his lawyer said.\nClergy representatives said they were unable to comment on the claims published in the Guardian as they formed part of an active investigation.\nThe priest said all five men were aware of his claims he had been repeatedly raped by a vicar when he was 16 in 1984, but none of them acted.\nHe said he made the allegations verbally to the Right Reverend Peter Burrows, the Bishop of Doncaster; the Right Reverend Steven Croft, the former Bishop of Sheffield, and now Bishop of Oxford; and the Right Reverend Martyn Snow, a former Archdeacon of Sheffield and Rotherham, and now the Bishop of Leicester, between July 2012 and February 2013.\nThe Archbishop of York John Sentamu and the Right Reverend Glyn Webster, the Bishop of Beverley, were also made aware when they were copied in to a letter sent to the Rt Rev Croft in June 2013, he said.\nHis lawyer, David Greenwood, of Switalskis Solicitors, said the priest finally spoke up after a safeguarding issue in his own parish \"triggered his memories\".\n\"He reached out for help to the Bishop of Doncaster but found that he got no help, no support and no response,\" he said.\n\"He continued to try to elicit a response from the senior people in his diocese but got nothing.\"\nUnder the Church of England's clergy disciplinary measures a complaint must be made within one year of the alleged misconduct.\nAn application for permission to make complaints out of time has been lodged and is being considered by the church.\nMr Greenwood said a complaint had also been made to West Yorkshire Police and the details of the alleged misconduct passed to the Goddard Inquiry into Child Sexual Abuse.\nA spokesperson for the archbishop said he had only been sent a copy of the letter and the original recipient of the letter had \"a duty to respond and not the archbishop\".\nA spokesperson for the bishops said that if the complaint went forward \"our bishops will make a full response to the various allegations made in due course\".\nA complaint has also been made by the priest against Roy Williamson, a former bishop of Bradford and now an honorary assistant bishop with the diocese of Southwell and Nottingham, that he failed to act at the time of the abuse.\nA spokesperson for his diocese said: \"We cannot comment during a live investigation except to say that if approached by the authorities we will offer them every co-operation.\"\nWest Yorkshire Police said it is investigating a report of a historical serious sexual offence said to have occurred in the Bradford area in the 1980s.\nA force representative said: \"A crime has been recorded and a 69-year-old man has been spoken to in connection with the inquiry.\"",
+    "reference": "A priest has accused the Archbishop of York and four bishops of misconduct after they \"failed to act\" on allegations he was raped by a vicar.",
+    "prediction": "A priest who claims he was raped by a vicar in the 1980s has made a complaint to the Archbishop of York and four former bishops.",
+    "entities": [
+      {
+        "ent": "four",
+        "type": "CARDINAL",
+        "start": 108,
+        "end": 112,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.0038219827692955732,
+        "posterior_prob": 0.263117253780365
+      }
+    ]
+  },
+  {
+    "source": "Conlan and Donnelly have since turned professional and are not impacted by sanctions including an obligation to follow integrity education programmes.\nThe three boxers did not attempt to manipulate an event at the Rio Games.\nThe Olympic Council of Ireland and British Olympic Association were also sanctioned with a reprimand.\nParticipants are are not permitted to bet on Olympic events and the trio violated the Rio 2016 Rules on the Prevention of the Manipulation of Competitions.\nLondon 2012 bronze medallist Conlan, who suffered a controversial bantamweight quarter-final defeat in Rio, placed bets on boxing contests on 8 and 9 August.\nBoth bets, in his weight division but not on his two bouts, were lost.\nDonnelly betted on himself to lose his welterweight fight against Tuvshinbat Byamba on 11 August - the Ballymena man won on points.\nHis explanation to the IOC was that he had \"bet without intending to cheat by losing his match to win his bets, rather, winning the bets would be some compensation in the event he lost his match\".\nDonnelly lost at the quarter-final stage while middleweight Fowler, who also bet on boxing events, was beaten in his opening bout.\nThe IOC said the trio must successfully follow the IOC education programme to be eligible for Toyko.\nThe are also required to support, through active participation, education programmes organised by the either the AIBA, IOC or their Olympic association.\nThe Olympic Council of Ireland and British Olympic Association were \"sanctioned with a reprimand for not having properly informed its athletes about the content of the different rules applicable to them on the occasion of the Olympic Games in Rio, as well as about the content of the contract signed with them\".\nThey are both \"requested to make sure that the team preparation for the Olympic Games (winter and summer) includes complete education on the prevention of the manipulation of competitions and betting on the Olympic Games.\nMeanwhile. it is recommended that the AIBA put in place \"education programmes on the prevention of the manipulation of competitions and betting on the Olympic Games\".",
+    "reference": "Irish pair Michael Conlan and Steven Donnelly have been issued with \"severe reprimands\" along with Britain's Antony Fowler for betting on Olympic events.",
+    "prediction": "The International Olympic Committee (IOC) has fined Northern Ireland boxers Michael Conlan, Joe Fowler and Stephen Donnelly for betting on boxing events at Rio 2016.",
+    "entities": [
+      {
+        "ent": "Northern Ireland",
+        "type": "GPE",
+        "start": 52,
+        "end": 68,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.0022744496818631887,
+        "posterior_prob": 0.739027738571167
+      },
+      {
+        "ent": "Joe",
+        "type": "PERSON",
+        "start": 92,
+        "end": 95,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.009777548722922802,
+        "posterior_prob": 0.01043708622455597
+      },
+      {
+        "ent": "Stephen",
+        "type": "PERSON",
+        "start": 107,
+        "end": 114,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.016360171139240265,
+        "posterior_prob": 0.03747273609042168
+      }
+    ]
+  },
+  {
+    "source": "The National Trust is at Rhossili on Saturday, searching for remnants of a village which was engulfed by sand.\nRecent storms have eroded the cliffs below where the village was located, but there are fears further erosion will mean it will be lost in the sea.\nRobert Francis-Davies, chairman of Gower Landscape Partnership, said it would be \"a coup\" to find the remains.",
+    "reference": "People are being urged to help uncover traces of a 15th Century village on Gower before it is swept out to sea.",
+    "prediction": "A search is under way for the remains of a Pembrokeshire village which was wiped out by storms in the 1970s.",
+    "entities": [
+      {
+        "ent": "Pembrokeshire",
+        "type": "GPE",
+        "start": 43,
+        "end": 56,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 5.1805949624395e-05,
+        "posterior_prob": 0.008494790643453598
+      },
+      {
+        "ent": "the 1970s",
+        "type": "DATE",
+        "start": 98,
+        "end": 107,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.011568727903068066,
+        "posterior_prob": 0.01597689278423786
+      }
+    ]
+  },
+  {
+    "source": "The National Trust is at Rhossili on Saturday, searching for remnants of a village which was engulfed by sand.\nRecent storms have eroded the cliffs below where the village was located, but there are fears further erosion will mean it will be lost in the sea.\nRobert Francis-Davies, chairman of Gower Landscape Partnership, said it would be \"a coup\" to find the remains.",
+    "reference": "People are being urged to help uncover traces of a 15th Century village on Gower before it is swept out to sea.",
+    "prediction": "A search is under way for the remains of a Gwynedd village which was wiped out by storms in the 1950s.",
+    "entities": [
+      {
+        "ent": "Gwynedd village",
+        "type": "GPE",
+        "start": 43,
+        "end": 58,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 8.28078370318508e-08,
+        "posterior_prob": 0.08783017843961716
+      },
+      {
+        "ent": "the 1950s",
+        "type": "DATE",
+        "start": 92,
+        "end": 101,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.02092696912586689,
+        "posterior_prob": 0.017419910058379173
+      }
+    ]
+  },
+  {
+    "source": "The Welsh Rugby Union (WRU) said he had been told not to report for training with the rest of the players on Monday.\nIt is seeking clarification about an incident outside a fast food restaurant in the early hours of Tuesday.\nPolice attended and said a man was taken away by officers but no arrests were made.\nThe WRU said while the player, aged 28, was on an agreed holiday period from pre-Rugby World Cup training it operated a strict code of conduct covering behaviour both on and off the field.\nWRU group chief executive Roger Lewis said: \"The player has been suspended due to a clear breach of the standards which we expect to be maintained by someone involved in one of our national squads.\n\"Discipline and acceptable behaviour are issues which run to the core values of the Welsh Rugby Union and we cannot tolerate any compromise of those standards.\n\"Mike Phillips is an exceptional player, but there is irrefutable evidence ... that he was engaged in behaviour which falls below the standards we set.\n\"It is vitally important that we send out a clear and unambiguous message to one and all concerning our views on matters of this sort.\n\"That message must be heard clearly by all players, coaches, administrators, volunteers, supporters and, of course, the parents and guardians of any child attracted to take part in the national sport of Wales.\n\"Our senior national squad players are highly visible because of the profile which accompanies the success of our national sport and it is made clear to them that they are the ambassadors we rely on to foster and sustain our image.\"\nThe incident occurred outside a McDonald's restaurant in Queen Street.\nFootage taken by bystanders shows Phillips being restrained by police before being led away in handcuffs to a police van.\nSouth Wales Police say he was not arrested.\nThe player was recently released by the Ospreys regional rugby team after securing a move to French club Bayonne.\nThe WRU said the suspension has been approved by Wales head coach Warren Gatland and agreed by the senior squad management team.\nWales team manager Alan Phillips said: \"We have suspended Mike Phillips on the clear evidence of a level of behaviour we regard as unacceptable.\n\"It is clear there has been a breach of our disciplinary standards.\"\nCardiff Blues scrum-half Lloyd Williams has been called into the Wales Rugby World Cup training squad as a replacement and will report for duty on Monday.",
+    "reference": "Scrum-half Mike Phillips has been suspended indefinitely from Wales squad duties after a late night incident in Cardiff.",
+    "prediction": "Former Ospreys scrum-half Mike Phillips has been suspended from the Wales squad after an incident in Cardiff city centre.",
+    "entities": [
+      {
+        "ent": "Cardiff city",
+        "type": "GPE",
+        "start": 101,
+        "end": 113,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.00021662221115548164,
+        "posterior_prob": 0.5687061548233032
+      }
+    ]
+  },
+  {
+    "source": "The Welsh Rugby Union (WRU) said he had been told not to report for training with the rest of the players on Monday.\nIt is seeking clarification about an incident outside a fast food restaurant in the early hours of Tuesday.\nPolice attended and said a man was taken away by officers but no arrests were made.\nThe WRU said while the player, aged 28, was on an agreed holiday period from pre-Rugby World Cup training it operated a strict code of conduct covering behaviour both on and off the field.\nWRU group chief executive Roger Lewis said: \"The player has been suspended due to a clear breach of the standards which we expect to be maintained by someone involved in one of our national squads.\n\"Discipline and acceptable behaviour are issues which run to the core values of the Welsh Rugby Union and we cannot tolerate any compromise of those standards.\n\"Mike Phillips is an exceptional player, but there is irrefutable evidence ... that he was engaged in behaviour which falls below the standards we set.\n\"It is vitally important that we send out a clear and unambiguous message to one and all concerning our views on matters of this sort.\n\"That message must be heard clearly by all players, coaches, administrators, volunteers, supporters and, of course, the parents and guardians of any child attracted to take part in the national sport of Wales.\n\"Our senior national squad players are highly visible because of the profile which accompanies the success of our national sport and it is made clear to them that they are the ambassadors we rely on to foster and sustain our image.\"\nThe incident occurred outside a McDonald's restaurant in Queen Street.\nFootage taken by bystanders shows Phillips being restrained by police before being led away in handcuffs to a police van.\nSouth Wales Police say he was not arrested.\nThe player was recently released by the Ospreys regional rugby team after securing a move to French club Bayonne.\nThe WRU said the suspension has been approved by Wales head coach Warren Gatland and agreed by the senior squad management team.\nWales team manager Alan Phillips said: \"We have suspended Mike Phillips on the clear evidence of a level of behaviour we regard as unacceptable.\n\"It is clear there has been a breach of our disciplinary standards.\"\nCardiff Blues scrum-half Lloyd Williams has been called into the Wales Rugby World Cup training squad as a replacement and will report for duty on Monday.",
+    "reference": "Scrum-half Mike Phillips has been suspended indefinitely from Wales squad duties after a late night incident in Cardiff.",
+    "prediction": "Wales scrum-half Mike Phillips has been suspended from the national squad after being involved in an incident in Cardiff city centre.",
+    "entities": [
+      {
+        "ent": "the national squad",
+        "type": "ORG",
+        "start": 55,
+        "end": 73,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.00038123084232211113,
+        "posterior_prob": 0.00012660599895752966
+      }
+    ]
+  },
+  {
+    "source": "Some pupils faced transport fees of \u00a3400 a year under the proposals from the Conservative-controlled council.\nIt has agreed to defer the cuts and take another look at the proposals.\nConservative councillor Lesley Pendleton said the main aim was to cut council expenditures, but added the proposals would now be reconsidered.\nCouncillor Pendleton, said: \"We felt it was a little too soon to make an immediate decision so we are going to have another look to make sure everything is as it should be.\"\nShe added the council would look to see \"whether there is actually some money we can claw out from somewhere\" to pay for the transport costs.\n\"I have changed my tune a little but then that is democracy isn't it. You have to listen to everybody,\" she added.\nLiberal Democrat opposition leader Simon Galton said: \"I am delighted that the Tories listened to us. What they had proposed had no public support and it was clear that this was a cut too far.\"\nThe authority had proposed to cut \u00a31.3m a year by making changes to the way home-to-school transport and some concessionary travel was funded.\nProposals included withdrawing bus subsidies for pupils of faith or voluntary-aided schools and over-16s.\nThe Conservative-run authority is aiming to save \u00a374m over four years.",
+    "reference": "Plans to cut a school transport budget have been deferred by Leicestershire County Council after opposition from residents and councillors.",
+    "prediction": "Plans to cut home-to-school transport subsidies in Gloucestershire have been put on hold.",
+    "entities": [
+      {
+        "ent": "Gloucestershire",
+        "type": "GPE",
+        "start": 51,
+        "end": 66,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.00010793079127324745,
+        "posterior_prob": 0.06997747719287872
+      }
+    ]
+  },
+  {
+    "source": "Some pupils faced transport fees of \u00a3400 a year under the proposals from the Conservative-controlled council.\nIt has agreed to defer the cuts and take another look at the proposals.\nConservative councillor Lesley Pendleton said the main aim was to cut council expenditures, but added the proposals would now be reconsidered.\nCouncillor Pendleton, said: \"We felt it was a little too soon to make an immediate decision so we are going to have another look to make sure everything is as it should be.\"\nShe added the council would look to see \"whether there is actually some money we can claw out from somewhere\" to pay for the transport costs.\n\"I have changed my tune a little but then that is democracy isn't it. You have to listen to everybody,\" she added.\nLiberal Democrat opposition leader Simon Galton said: \"I am delighted that the Tories listened to us. What they had proposed had no public support and it was clear that this was a cut too far.\"\nThe authority had proposed to cut \u00a31.3m a year by making changes to the way home-to-school transport and some concessionary travel was funded.\nProposals included withdrawing bus subsidies for pupils of faith or voluntary-aided schools and over-16s.\nThe Conservative-run authority is aiming to save \u00a374m over four years.",
+    "reference": "Plans to cut a school transport budget have been deferred by Leicestershire County Council after opposition from residents and councillors.",
+    "prediction": "Plans to cut home-to-school transport subsidies for children in Flintshire have been put on hold.",
+    "entities": [
+      {
+        "ent": "Flintshire",
+        "type": "PERSON",
+        "start": 64,
+        "end": 74,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 5.601058546744753e-06,
+        "posterior_prob": 0.05400919169187546
+      }
+    ]
+  },
+  {
+    "source": "Some pupils faced transport fees of \u00a3400 a year under the proposals from the Conservative-controlled council.\nIt has agreed to defer the cuts and take another look at the proposals.\nConservative councillor Lesley Pendleton said the main aim was to cut council expenditures, but added the proposals would now be reconsidered.\nCouncillor Pendleton, said: \"We felt it was a little too soon to make an immediate decision so we are going to have another look to make sure everything is as it should be.\"\nShe added the council would look to see \"whether there is actually some money we can claw out from somewhere\" to pay for the transport costs.\n\"I have changed my tune a little but then that is democracy isn't it. You have to listen to everybody,\" she added.\nLiberal Democrat opposition leader Simon Galton said: \"I am delighted that the Tories listened to us. What they had proposed had no public support and it was clear that this was a cut too far.\"\nThe authority had proposed to cut \u00a31.3m a year by making changes to the way home-to-school transport and some concessionary travel was funded.\nProposals included withdrawing bus subsidies for pupils of faith or voluntary-aided schools and over-16s.\nThe Conservative-run authority is aiming to save \u00a374m over four years.",
+    "reference": "Plans to cut a school transport budget have been deferred by Leicestershire County Council after opposition from residents and councillors.",
+    "prediction": "Plans to cut home-to-school transport subsidies for children in Staffordshire have been put on hold.",
+    "entities": [
+      {
+        "ent": "Staffordshire",
+        "type": "GPE",
+        "start": 64,
+        "end": 77,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.00017156302055809647,
+        "posterior_prob": 0.12596124410629272
+      }
+    ]
+  },
+  {
+    "source": "Some pupils faced transport fees of \u00a3400 a year under the proposals from the Conservative-controlled council.\nIt has agreed to defer the cuts and take another look at the proposals.\nConservative councillor Lesley Pendleton said the main aim was to cut council expenditures, but added the proposals would now be reconsidered.\nCouncillor Pendleton, said: \"We felt it was a little too soon to make an immediate decision so we are going to have another look to make sure everything is as it should be.\"\nShe added the council would look to see \"whether there is actually some money we can claw out from somewhere\" to pay for the transport costs.\n\"I have changed my tune a little but then that is democracy isn't it. You have to listen to everybody,\" she added.\nLiberal Democrat opposition leader Simon Galton said: \"I am delighted that the Tories listened to us. What they had proposed had no public support and it was clear that this was a cut too far.\"\nThe authority had proposed to cut \u00a31.3m a year by making changes to the way home-to-school transport and some concessionary travel was funded.\nProposals included withdrawing bus subsidies for pupils of faith or voluntary-aided schools and over-16s.\nThe Conservative-run authority is aiming to save \u00a374m over four years.",
+    "reference": "Plans to cut a school transport budget have been deferred by Leicestershire County Council after opposition from residents and councillors.",
+    "prediction": "Plans to cut home-to-school transport subsidies for children in Gloucesterse have been put on hold.",
+    "entities": [
+      {
+        "ent": "Gloucesterse",
+        "type": "ORG",
+        "start": 64,
+        "end": 76,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 2.3609619467790388e-11,
+        "posterior_prob": 1.1057961657456872e-08
+      }
+    ]
+  },
+  {
+    "source": "Some pupils faced transport fees of \u00a3400 a year under the proposals from the Conservative-controlled council.\nIt has agreed to defer the cuts and take another look at the proposals.\nConservative councillor Lesley Pendleton said the main aim was to cut council expenditures, but added the proposals would now be reconsidered.\nCouncillor Pendleton, said: \"We felt it was a little too soon to make an immediate decision so we are going to have another look to make sure everything is as it should be.\"\nShe added the council would look to see \"whether there is actually some money we can claw out from somewhere\" to pay for the transport costs.\n\"I have changed my tune a little but then that is democracy isn't it. You have to listen to everybody,\" she added.\nLiberal Democrat opposition leader Simon Galton said: \"I am delighted that the Tories listened to us. What they had proposed had no public support and it was clear that this was a cut too far.\"\nThe authority had proposed to cut \u00a31.3m a year by making changes to the way home-to-school transport and some concessionary travel was funded.\nProposals included withdrawing bus subsidies for pupils of faith or voluntary-aided schools and over-16s.\nThe Conservative-run authority is aiming to save \u00a374m over four years.",
+    "reference": "Plans to cut a school transport budget have been deferred by Leicestershire County Council after opposition from residents and councillors.",
+    "prediction": "Plans to cut home-to-school transport subsidies for children in Gloucestersfield have been put on hold.",
+    "entities": [
+      {
+        "ent": "Gloucestersfield",
+        "type": "PERSON",
+        "start": 64,
+        "end": 80,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 1.7212251068876583e-10,
+        "posterior_prob": 7.469494448741898e-06
+      }
+    ]
+  },
+  {
+    "source": "Some pupils faced transport fees of \u00a3400 a year under the proposals from the Conservative-controlled council.\nIt has agreed to defer the cuts and take another look at the proposals.\nConservative councillor Lesley Pendleton said the main aim was to cut council expenditures, but added the proposals would now be reconsidered.\nCouncillor Pendleton, said: \"We felt it was a little too soon to make an immediate decision so we are going to have another look to make sure everything is as it should be.\"\nShe added the council would look to see \"whether there is actually some money we can claw out from somewhere\" to pay for the transport costs.\n\"I have changed my tune a little but then that is democracy isn't it. You have to listen to everybody,\" she added.\nLiberal Democrat opposition leader Simon Galton said: \"I am delighted that the Tories listened to us. What they had proposed had no public support and it was clear that this was a cut too far.\"\nThe authority had proposed to cut \u00a31.3m a year by making changes to the way home-to-school transport and some concessionary travel was funded.\nProposals included withdrawing bus subsidies for pupils of faith or voluntary-aided schools and over-16s.\nThe Conservative-run authority is aiming to save \u00a374m over four years.",
+    "reference": "Plans to cut a school transport budget have been deferred by Leicestershire County Council after opposition from residents and councillors.",
+    "prediction": "Plans to cut school bus subsidies for children in West Lothian have been shelved after opposition from councillors.",
+    "entities": [
+      {
+        "ent": "West Lothian",
+        "type": "GPE",
+        "start": 50,
+        "end": 62,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.00014071773330215365,
+        "posterior_prob": 0.0001220920676132664
+      }
+    ]
+  },
+  {
+    "source": "Dave and Leslie Blissett, of Lincolnshire, bought the Tornado GR1 - extensively involved in the 1991 conflict - as a shell.\nFor sale on Gumtree, it has no engine, or guns and the wings have been removed for transportation purposes.\nThe ex-RAF engineers, whose love of aeroplanes brought them together, said it would make an ideal museum display.\nMr Blissett said he has always had a passion for taking things apart.\nHe took on the project after being involved in the restoration of a Lightning jet at RAF Binbrook, near Market Rasen.\n\"What we started with was literally a bare frame - you couldn't recognise it as a Tornado,\" he said.\n\"Over the years we've bought, swapped and gone through scrap bins to get it to where it is now.\"\nMrs Blissett said when it first arrived it looked like a \"metal caterpillar on the back of a lorry\".\n\"Some people go for garden gnomes, we go for aeroplanes,\" she said.\nThe Panavia Tornado GR1 was used extensively in combat by the RAF in 1990s, including in the Gulf War in 1991.\nOn the classified ads website, the couple have written: \"She is virtually complete and is ready to move as her wings have already been removed.\"\nAndrew Panton, manager of the Lincolnshire Aviation Heritage Centre, said it was \"unusual\" to sell aircraft on Gumtree, as they are generally sold via the Ministry of Defence surplus service.\n\"They way they are doing it - making it known worldwide - could work in their favour,\" he said.\nAs interesting as the piece is, it is the \"wrong era\" for the centre in Spilsby, which focuses on World War II aircraft, he said.",
+    "reference": "A Gulf War-era fighter jet has been put on sale online for \u00a320,000 by a couple who took six years to rebuild it.",
+    "prediction": "A World War Two fighter jet that was used in the Gulf War has been put up for sale by two ex-RAF engineers.",
+    "entities": [
+      {
+        "ent": "World War Two",
+        "type": "EVENT",
+        "start": 2,
+        "end": 15,
+        "in_source": false,
+        "label": "Intrinsic Hallucination",
+        "prior_prob": 0.007740031462162733,
+        "posterior_prob": 0.03615478798747063
+      }
+    ]
+  },
+  {
+    "source": "Dave and Leslie Blissett, of Lincolnshire, bought the Tornado GR1 - extensively involved in the 1991 conflict - as a shell.\nFor sale on Gumtree, it has no engine, or guns and the wings have been removed for transportation purposes.\nThe ex-RAF engineers, whose love of aeroplanes brought them together, said it would make an ideal museum display.\nMr Blissett said he has always had a passion for taking things apart.\nHe took on the project after being involved in the restoration of a Lightning jet at RAF Binbrook, near Market Rasen.\n\"What we started with was literally a bare frame - you couldn't recognise it as a Tornado,\" he said.\n\"Over the years we've bought, swapped and gone through scrap bins to get it to where it is now.\"\nMrs Blissett said when it first arrived it looked like a \"metal caterpillar on the back of a lorry\".\n\"Some people go for garden gnomes, we go for aeroplanes,\" she said.\nThe Panavia Tornado GR1 was used extensively in combat by the RAF in 1990s, including in the Gulf War in 1991.\nOn the classified ads website, the couple have written: \"She is virtually complete and is ready to move as her wings have already been removed.\"\nAndrew Panton, manager of the Lincolnshire Aviation Heritage Centre, said it was \"unusual\" to sell aircraft on Gumtree, as they are generally sold via the Ministry of Defence surplus service.\n\"They way they are doing it - making it known worldwide - could work in their favour,\" he said.\nAs interesting as the piece is, it is the \"wrong era\" for the centre in Spilsby, which focuses on World War II aircraft, he said.",
+    "reference": "A Gulf War-era fighter jet has been put on sale online for \u00a320,000 by a couple who took six years to rebuild it.",
+    "prediction": "A World War Two aircraft that was used in the Gulf War is being sold for \u00a31,000.",
+    "entities": [
+      {
+        "ent": "1,000",
+        "type": "MONEY",
+        "start": 74,
+        "end": 79,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 2.6270569719599735e-08,
+        "posterior_prob": 4.5731503632850945e-05
+      }
+    ]
+  },
+  {
+    "source": "After Everton striker Lukaku's fiercely struck opener from outside the box, Bournemouth's Joshua King levelled.\nVeton Berisha profited from static defending as Norway then led, but Hazard deftly headed in an equaliser and Laurent Ciman got the winner.\nMeanwhile, Russia, who begin their Euro 2016 campaign against England on Saturday, drew 1-1 with Serbia.\nThey were denied victory by an 88th-minute equaliser from Newcastle striker Aleksandar Mitrovic, having taken the lead through Artem Dzyuba in the 85th minute.\nEarlier, Czech Republic suffered a 2-1 home defeat by South Korea in their final warm-up game.\nYoon Bit-garam and Suk Hyun-jun gave the away side a 2-0 half-time lead before Marek Suchy got one back and Theodor Gebre Selassie was sent off for a second yellow card.\nMatch ends, Belgium 3, Norway 2.\nSecond Half ends, Belgium 3, Norway 2.\nFoul by Marouane Fellaini (Belgium).\nRuben Jenssen (Norway) wins a free kick in the defensive half.\nFoul by Divock Origi (Belgium).\nJonas Svensson (Norway) wins a free kick on the right wing.\nCorner,  Norway. Conceded by Marouane Fellaini.\nSubstitution, Belgium. Mousa Demb\u00e9l\u00e9 replaces Eden Hazard.\nRomelu Lukaku (Belgium) wins a free kick in the defensive half.\nFoul by Ruben Jenssen (Norway).\nLaurent Ciman (Belgium) wins a free kick in the defensive half.\nFoul by Valon Berisha (Norway).\nAttempt missed. Marouane Fellaini (Belgium) header from very close range misses to the right. Assisted by Eden Hazard with a cross following a corner.\nSubstitution, Norway. Alexander S\u00f8rloth replaces Joshua King.\nCorner,  Belgium. Conceded by Jonas Svensson.\nSubstitution, Belgium. Divock Origi replaces Dries Mertens.\nAttempt missed. Valon Berisha (Norway) right footed shot from outside the box misses to the right. Assisted by Ruben Jenssen.\nAttempt saved. Kevin De Bruyne (Belgium) right footed shot from outside the box is saved in the centre of the goal.\nJonas Svensson (Norway) is shown the yellow card for a bad foul.\nEden Hazard (Belgium) wins a free kick in the attacking half.\nFoul by Jonas Svensson (Norway).\nJordan Lukaku (Belgium) is shown the yellow card for a bad foul.\nFoul by Jordan Lukaku (Belgium).\nMarkus Henriksen (Norway) wins a free kick in the defensive half.\nHand ball by Ruben Jenssen (Norway).\nOffside, Belgium. Thibaut Courtois tries a through ball, but Kevin De Bruyne is caught offside.\nSubstitution, Norway. Ruben Jenssen replaces Stefan Johansen.\nRadja Nainggolan (Belgium) wins a free kick in the defensive half.\nFoul by Markus Henriksen (Norway).\nGoal!  Belgium 3, Norway 2. Laurent Ciman (Belgium) header from very close range to the centre of the goal. Assisted by Toby Alderweireld with a headed pass following a corner.\nSubstitution, Norway. Stefan Strandberg replaces Ole Selnaes.\nSubstitution, Norway. Iver Fossum replaces Veton Berisha.\nCorner,  Belgium. Conceded by Haitam Aleesami.\nAttempt blocked. Romelu Lukaku (Belgium) left footed shot from the centre of the box is blocked. Assisted by Kevin De Bruyne with a through ball.\nAttempt missed. Dries Mertens (Belgium) right footed shot from the right side of the six yard box is too high. Assisted by Jordan Lukaku.\nAttempt missed. Jordan Lukaku (Belgium) left footed shot from a difficult angle on the left misses to the right. Assisted by Romelu Lukaku.\nGoal!  Belgium 2, Norway 2. Eden Hazard (Belgium) header from the centre of the box to the bottom left corner. Assisted by Kevin De Bruyne with a cross.\nCorner,  Norway. Conceded by Toby Alderweireld.\nAttempt blocked. Joshua King (Norway) right footed shot from the right side of the box is blocked. Assisted by Markus Henriksen.\nSubstitution, Norway. Valon Berisha replaces Adama Diomande.",
+    "reference": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final game before Euro 2016.",
+    "prediction": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup warm-up.",
+    "entities": [
+      {
+        "ent": "World Cup",
+        "type": "EVENT",
+        "start": 95,
+        "end": 104,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.16766169667243958,
+        "posterior_prob": 0.034886427223682404
+      }
+    ]
+  },
+  {
+    "source": "Batsman Root is the favourite to take over from Alastair Cook, who stepped down on Monday after a record 59 Tests.\nThe Yorkshire player had been Test vice-captain to Cook since May 2015.\n\"Root is fairly quiet but he has got that fire in his belly. He's a really impressive young man,\" Anderson told The Tuffers and Vaughan Cricket Show.\nShould he be named captain aged 26, Root would be a year younger than Cook was when he took on the Test role on a full-time basis in August 2012.\nNo batsman has scored more Test runs than Root's 4,594 since he made his debut on 13 December 2012, and only India captain Virat Kohli (8,536) has scored more runs than Root's 8,469 in all three forms of international cricket.\nAnderson, England's leading Test wicket-taker, has played under five full-time Test captains since making his debut in May 2003.\nThe 34-year-old has served Nasser Hussain, Michael Vaughan, Kevin Pietersen, Andrew Strauss and Cook, as well as Andrew Flintoff who deputised for several Tests in 2006 and 2007.\n\"Root gets into situations, one-on-ones, with people. He speaks a lot of sense when he does speak and he's a really impressive young man,\" explained Anderson.\n\"He's the obvious candidate. The decision is a big one because he's our best player, so you obviously don't want that to be affected.\"\nMedia playback is not supported on this device\nWhile they do not play another Test until July, England then play seven home Test matches - against South Africa and West Indies - in three months, before travelling to Australia in November for the Ashes.\nRoot scored 1,477 Test runs in 2016, making centuries against South Africa, Pakistan and India, as well as scoring 796 runs in one-day internationals and 297 in Twenty20 internationals.\n\"He loves cricket. It's very rare you see a player that's had the success he's had and he's not like that,\" Anderson said.\n\"In the brief period Alastair Cook's been off the field -  for bathroom breaks -  Root's been in there making changes. He's been good.\n\"It can be a difficult situation for a vice-captain when the captain goes off, you're in charge and myself and Stuart [Broad] might not make it that easy to go up and talk tactics. However he's done that and he's been good.\"\nRoot has led Yorkshire four times in the County Championship, taking charge when the county secured the 2014 County Championship title after then-captain Andrew Gale was suspended.\nHe was also the on-field captain when Middlesex, led by Australian batsman Chris Rogers, made a record 472-3 to beat Yorkshire by seven wickets in the same year.\nAll-rounder Ben Stokes, who was vice-captain on the recent limited-overs tour of Bangladesh which regular ODI skipper Eoin Morgan missed, was described as a \"natural leader\" by his Durham skipper Paul Collingwood.\n\"Ben has got a natural draw to him and he would be an excellent vice-captain for Root,\" former England limited-overs captain Collingwood said on the Tuffers and Vaughan show.\n\"The captain will have leaders underneath him that he knows he can go to - I think Ben Stokes would be the perfect man for that.\"\nFast bowler Stuart Broad has also been mooted - he captained the Twenty20 side between 2011 and 2014 - and Anderson said: \"I wouldn't be against a fast bowler but one issue could be fitness.\n\"Bowlers get injured a lot more so are they going to play every game? The international schedule is hectic so it can be difficult.\"\nWicketkeeper Jos Buttler, who led the one-day side in Bangladesh in Morgan's absence and remains the official limited-overs vice-captain, has also been suggested as a possible candidate.\nHowever, the Lancashire player's Test place is not guaranteed given current keeper Jonny Bairstow's good form - although Buttler played as a specialist batsman in the last three Tests of the recent India series.\nEx-England spinner Graeme Swann told BBC Radio 5 live he felt the pressure of potential Test captaincy was already affecting Root's batting.\n\"I think we should leave Joe Root to be the best batsman this country has ever produced, which he would be without the burden of being the captain,\" he said.\nHowever, Kohli, along with Australia's Steve Smith and New Zealand's Kane Williamson, have each raised their games since becoming captains of their respective countries.\nSmith and Kohli are the two top-ranked Test batsmen, while Williamson is one of 13 men to have scored a Test century against all of the other nine Test-playing nations.\n\"It's very English to assume the captaincy will affect him. The other three have got captaincy of their country and gone to a different level with it,\" said ex-England skipper Michael Vaughan, who came through the same Sheffield Collegiate club side and Yorkshire academy ranks which produced Root, and has been a long-term mentor to the young right-hander.\n\"I don't think there's an issue with him captaining, he's too good a player. I think he'd be a good one.\n\"To captain any team you have to be loving the game, love the difficult moments and prove people wrong. He is that kind of character.\"\nEngland and Yorkshire batsman Gary Ballance, who was named captain of the county in December 2016, said that his team-mate Root's inexperience was not an issue in him assuming the captaincy.\nThe pair lived together in 2011 during their early years in the Yorkshire first team and Ballance took Root's place when he was dropped for the final Test of England's Ashes whitewash in Australia in 2013-14.\n\"I think both of us have probably matured a bit more as cricketers and people. He's ready as a leader now in that England changing room,\" Ballance told BBC World Service's Stumped programme.\n\"I think Rooty's a natural born leader. He's done it from a young age. People follow him.\n\"He speaks well, he's got a great cricket brain. I don't think inexperience is too much of a problem. He'll be ready if he gets the opportunity.\"",
+    "reference": "Joe Root is the \"obvious candidate\" to be named as England Test captain - but the role must not affect his batting, says pace bowler James Anderson.",
+    "prediction": "Joe Root has the \"fire in his belly\" to become England Test captain, says fast bowler James Anderson.",
+    "entities": [
+      {
+        "ent": "England Test",
+        "type": "ORG",
+        "start": 47,
+        "end": 59,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.0032933359034359455,
+        "posterior_prob": 0.35053324699401855
+      }
+    ]
+  },
+  {
+    "source": "Police were called to a unit at Derwent Works, Matlock Road, Ambergate, at about 20:00 BST on Sunday following reports a man had been injured.\nThe man, believed to be 19, was later confirmed dead in hospital.\nA file is being prepared for the coroner, but the force does not believe there are any suspicious circumstances surrounding the death.",
+    "reference": "A man has died after apparently falling through the roof of a building at an industrial site in Derbyshire.",
+    "prediction": "A man has died following an incident at a recycling centre in Nottinghamshire.",
+    "entities": [
+      {
+        "ent": "Nottinghamshire",
+        "type": "GPE",
+        "start": 62,
+        "end": 77,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 1.1897329386556521e-05,
+        "posterior_prob": 0.013226330280303955
+      }
+    ]
+  },
+  {
+    "source": "The 30-year-old is to remain there following the completion of a psychiatric report.\nBelfast Magistrates' Court was told she would not be able to leave without the hospital's permission.\nThe woman cannot be named amid claims that identifying her would increase the risk of her taking her own life.\nA press challenge to the temporary reporting restrictions is due to be heard next month.\nThe woman was arrested by detectives investigating the child's death following an incident in Belfast in March.\nShe was charged with murder and then held under the Mental Health Act.\nHer barrister revealed on Wednesday that a medical report had now been prepared.\nBased on its contents he sought a termination of the current arrangements for keeping his client at the facility.\n\"The application is that she be remanded on bail, subject to the condition that she continues to reside (there),\" he said.\nA doctor who assessed the accused confirmed that the health trust consented to the proposal, provided the accused was there as a detained person.\nThe judge was informed that under those arrangements the woman would not be able to leave.\nGranting the application, she listed the criminal proceedings for a further update in eight weeks time.",
+    "reference": "A woman accused of murdering her baby son has been remanded on bail at a mental health facility.",
+    "prediction": "A woman charged with murdering her two-year-old daughter has been remanded in custody at the Royal Victoria Hospital in Belfast.",
+    "entities": [
+      {
+        "ent": "two-year-old",
+        "type": "DATE",
+        "start": 35,
+        "end": 47,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0406271293759346,
+        "posterior_prob": 0.06650076806545258
+      }
+    ]
+  },
+  {
+    "source": "The 30-year-old is to remain there following the completion of a psychiatric report.\nBelfast Magistrates' Court was told she would not be able to leave without the hospital's permission.\nThe woman cannot be named amid claims that identifying her would increase the risk of her taking her own life.\nA press challenge to the temporary reporting restrictions is due to be heard next month.\nThe woman was arrested by detectives investigating the child's death following an incident in Belfast in March.\nShe was charged with murder and then held under the Mental Health Act.\nHer barrister revealed on Wednesday that a medical report had now been prepared.\nBased on its contents he sought a termination of the current arrangements for keeping his client at the facility.\n\"The application is that she be remanded on bail, subject to the condition that she continues to reside (there),\" he said.\nA doctor who assessed the accused confirmed that the health trust consented to the proposal, provided the accused was there as a detained person.\nThe judge was informed that under those arrangements the woman would not be able to leave.\nGranting the application, she listed the criminal proceedings for a further update in eight weeks time.",
+    "reference": "A woman accused of murdering her baby son has been remanded on bail at a mental health facility.",
+    "prediction": "A woman charged with murdering her six-month-old baby has been remanded in custody at Belfast General Hospital.",
+    "entities": [
+      {
+        "ent": "six-month-old",
+        "type": "DATE",
+        "start": 35,
+        "end": 48,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.008098067715764046,
+        "posterior_prob": 0.07718111574649811
+      }
+    ]
+  },
+  {
+    "source": "The 30-year-old played for the county in 2011 and helped them reach the final of the domestic T20 competition and the Champions League semi-finals.\n\"I enjoyed my time in Taunton and I am really looking forward to working with Matt Maynard again,\" he said.\n\"For me to be coming back to Somerset to contribute in all forms of the game is awesome.\"\nVan der Nerwe previously played under Somerset director of cricket Matthew Maynard in the Caribbean Premier League, for St Lucia Zouks.\nHe has represented South Africa at international level, but now plays for the Netherlands and is currently involved in the ICC World T20 qualifier.",
+    "reference": "Somerset have signed all-rounder Roelof van der Merwe on a two-year contract to start next season.",
+    "prediction": "Somerset have re-signed South Africa all-rounder Jacques van der Nerwe on a two-year deal.",
+    "entities": [
+      {
+        "ent": "Jacques",
+        "type": "PERSON",
+        "start": 49,
+        "end": 56,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0037674657069146633,
+        "posterior_prob": 0.033982135355472565
+      }
+    ]
+  },
+  {
+    "source": "More than 60 years on, with another World Cup looming in Brazil and the Indian economy booming, there are renewed hopes that football can finally gain a toehold in the cricket-loving country.\nQualification for the 2014 World Cup may be a step too far, but there are a number of initiatives under way to boost the sport.\nThe challenges are to nurture that growing interest while wooing fans away from watching overseas football on TV,  and the need to create a strong national league and international team.\nOff the pitch there is the need to build football industry and infrastructure, while boosting the expertise of administrators and coaching and other backroom staff.\n\"There is a challenge from cricket, which gets the most investment,\" admits Kushal Das, general secretary of the All India Football Federation (AIFF).\n\"Many youngsters though are now watching a lot of football, mainly European leagues.\n\"We need to develop interest in the Indian leagues, and we need development programmes for that.\"\nMr Das said he was encouraged by the recent visit of Fifa president Sepp Blatter to the country.\nThe country is hoping to host the Under-17 World Cup in 2017, and Mr Blatter has so far offered encouraging noises.\nMr Das said that highlights over the past couple of years included India playing in the AFC Asian Cup in 2011 for the first time in more than 20 years, and the 15-year commercial and marketing partnership between the AIFF and IMG-Reliance.\nEncouragement has also come from a recent development plan for football in India drawn up with Fifa.\n\"We are starting up academies for player development in four cities by July and another four by July 2013, for different age groups,\" says Mr Das.\nA technical director has also been appointed for the first time, unusual as it may seem that such a role did not exist before.\n\"We are looking not just at player development, but also administration, education, referees,\" says Mr Das.\n\"If we are successful in hosting the Under-17 there will be [business] opportunities, to participate in the whole development of Indian football - it is a great opportunity.\"\nHe adds: \"The biggest challenge is infrastructure. I hope, if we have the World Cup hosting rights, that there will be serious efforts to improve the infrastructure.\"\nIMG and stadium builders Populous have already been around the country looking at which existing stadiums could potentially be brought up to scratch for 2017.\nOne of the footballing hotbeds in the country is Pune, a city in the west of the country with a three million-plus population.\n\"Sport, including football, is tremendously popular among the youth of our city today,\" says Vishwajeet Kadam,  president of Pune District Football Association.\n\"We don't only focus on the skills development of players. We also taking to the FA and taking advice from the Indian Premier League cricket, and hockey, about ways to boost the football industry and surrounding football industry skills.\"\nPune also has contacts with English Premier League football clubs, including Liverpool and Blackburn Rovers, who both have training academies in the city.\n\"Other clubs have been to India to just hold training sessions, but Liverpool has shown a clear commitment,\" says Mr Kadam.\n\"Most European clubs seriously underestimate the Indian market.\n\"There are organisations in India ready to spend money in partnerships with European clubs.\"\nOne club which has formed a partnership is Italian side Inter Milan, which has entered a joint football venture with Tata Tea to support a youth football tournament in India, covering 15 cities, 1,000 schools, and one million children.\nMario de Vivo, Inter Milan chief commercial officer, adds: \"We then select 16 young Indian pupils and take them to Inter Milan training academy for three days.\n\"We are bringing to India not only technical skills, but also medical, nutritional, and psychological support.\n\"We are able to offer a complete platform to help young teams, federations, and other people that want to learn about football and improve the professional side.\"\nBusiness bodies in India also wants to improve transparency, accountability, marketing, planning and professionalism in football.\nRajpal Singh of the Federation of Indian Chambers of Commerce & Industry (Ficci) says: \"We realise in sport we need foreign expertise.\n\"We want to create a sporting culture in India, and bring about attitudinal change and develop a sporting infrastructure.\n\"India is a cricket country but over the past two years you can see a change in attitude. Sports people are now looking towards football.\n\"But we need to examine the whole football infrastructure.\"\nIMG-Reliance is bringing its sports industry expertise to India as part of its deal with the AIFF.\n\"Indians love football and can play football. If you buy into that premise then you know we will be successful,\" says IMG's Jefferson Slack.\nMr Slack admits there are challenges on the football and infrastructure side, but says there is a competitive media market in India that is \"going to need high quality football content\".\nHe adds: \"There are certainly some challenges. The existing league suffers from an??? organisation standpoint.\n\"The IPL [cricket] was instructive because it showed that a properly constructed franchise league could work.\n\"There is a lot of money in India to build a brand. Football needs to succeed. It needs a plan. We are are not there yet.\n\"But the long term view we have is that this will be lucrative.\"\nMeanwhile, uncertainty remains about the future of the proposed, but currently delayed, Premier Soccer League (PLS) in West Bengal.\nThe PLS was intended as a state league for older European players - such as Robert Pires and Fabio Cannavaro. It attracted publicity around the world, particularly in the UK.\nMr Slack said he understood the premise of the league as, he says, India is a country that is \"star driven\".\nBut he said there was a pressing need to boost the status of the current Indian national soccer league.\n\"We are in dialogue with I-League about how to make the league more competitive and attractive,\" he says.\n\"There are no easy solutions there. We completely understand that the clubs need to get more out of it.\"",
+    "reference": "When India qualified for the 1950 World Cup in Brazil they refused to participate - partly because it would have meant their normally bare foot team having to wear football boots.",
+    "prediction": "When India hosted the first World Cup in 1958, it was hailed as one of the greatest sporting achievements in the country's history.",
+    "entities": [
+      {
+        "ent": "1958",
+        "type": "DATE",
+        "start": 41,
+        "end": 45,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.001192150404676795,
+        "posterior_prob": 0.4952007830142975
+      }
+    ]
+  },
+  {
+    "source": "The pound jumped by 0.85%, or more than one euro cent, to \u00e2\u201a\u00ac1.4072, although against the dollar the pound was down 0.26% at $1.5783.\nOn the stock market, the FTSE 100 was 16.93 points higher at 6,842.60, adding to the sharp gains seen on Monday.\nHowever, the FTSE was lagging gains elsewhere, with Germany's Dax and France's Cac 40 both up more than 1%.\nShares in business supplies distributor Bunzl dropped 1.6% - the biggest faller in the FTSE 100 - after it said organic revenue growth had slowed in the first half of its financial year.\nBunzl also announced it had bought four businesses in the US, Colombia, Canada and France.\nHowever, the most eye-catching move was in the FTSE 250, where shares in Ladbrokes jumped 16% after it said it was in merger talks with Gala Coral.",
+    "reference": "(Noon): The pound hit a four-week high against the euro as the single currency weakened on Tuesday.",
+    "prediction": "(Close): The pound rose against the euro and the dollar on Tuesday, after the Bank of England raised its interest rate to 0.5%.",
+    "entities": [
+      {
+        "ent": "0.5%",
+        "type": "PERCENT",
+        "start": 122,
+        "end": 126,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.00029744920902885497,
+        "posterior_prob": 0.036039020866155624
+      }
+    ]
+  },
+  {
+    "source": "The pound jumped by 0.85%, or more than one euro cent, to \u00e2\u201a\u00ac1.4072, although against the dollar the pound was down 0.26% at $1.5783.\nOn the stock market, the FTSE 100 was 16.93 points higher at 6,842.60, adding to the sharp gains seen on Monday.\nHowever, the FTSE was lagging gains elsewhere, with Germany's Dax and France's Cac 40 both up more than 1%.\nShares in business supplies distributor Bunzl dropped 1.6% - the biggest faller in the FTSE 100 - after it said organic revenue growth had slowed in the first half of its financial year.\nBunzl also announced it had bought four businesses in the US, Colombia, Canada and France.\nHowever, the most eye-catching move was in the FTSE 250, where shares in Ladbrokes jumped 16% after it said it was in merger talks with Gala Coral.",
+    "reference": "(Noon): The pound hit a four-week high against the euro as the single currency weakened on Tuesday.",
+    "prediction": "The pound hit a fresh seven-year high against the euro on Monday, after the Bank of England raised interest rates.",
+    "entities": [
+      {
+        "ent": "seven-year",
+        "type": "DATE",
+        "start": 22,
+        "end": 32,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.028017688542604446,
+        "posterior_prob": 0.028071176260709763
+      }
+    ]
+  },
+  {
+    "source": "A referendum on the UK's membership of the EU is to be held later this year.\nThe survey indicates that only 11% of of the chamber's members in Northern Ireland support a British exit (Brexit).\nThat compares to 30% of those surveyed in the rest of the UK.\nThe Chamber of Commerce has about 1,200 members in Northern Ireland.\nAbout 250 of those responded to the poll.\nMore than half of the respondents (60%) said that Prime Minister David Cameron's renegotiated EU deal is unlikely to change how they will vote.\nThe results come on the eve of crunch Brussels talks, which are expected to result in a deal.\nEighty-four per cent of those surveyed in Northern Ireland  also say that there has been no impact on their sales and orders as of yet, due to the uncertainty of Britain's future within the EU.\nCommenting on the results, President of Northern Ireland Chamber of Commerce Stephen McCully said the findings suggest that \"the renegotiation is having little impact on day-to-day business - or the vote of the business community\".\nHe said that this was because many made up their minds before knowing the outcome of negotiations, effectively discounting them as irrelevant.\n\"For businesspeople, this is a question of in or out,\" he said.\n\"Those within Northern Ireland who are firmly wedded to the EU have said that Brexit will leave us stranded outside the EU, and coping with the re-emergence of a land border with the Republic of Ireland.\n\"Emotion has a part in all decision making and it will do so here, but there is a duty to ensure decisions are as well informed as they can be.\"\nClarification: An earlier version of this article omitted the number of respondents to the Chamber of Commerce survey.",
+    "reference": "A survey of Chamber of Commerce members in Northern Ireland suggests that 81% will vote for the UK to remain in the European Union (EU).",
+    "prediction": "The Northern Ireland Chamber of Commerce has said that the renegotiation of the UK's EU deal will have little impact on day-to-day business.",
+    "entities": [
+      {
+        "ent": "The Northern Ireland Chamber of Commerce",
+        "type": "ORG",
+        "start": 0,
+        "end": 40,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 1.1325559413910558e-11,
+        "posterior_prob": 3.175650135744945e-06
+      }
+    ]
+  },
+  {
+    "source": "The units in North Tyneside and Northumberland have been shut between midnight and 08:00 since December.\nOvernight emergencies have been diverted to the recently-opened Northumbria Hospital in Cramlington.\nThe closures at North Tyneside, Hexham and Wansbeck hospitals, will continue for a further three months.\nThe Northumbria Healthcare NHS Foundation Trust said the impact on patients had been minimal as the units were underused at night.\nStaff from the units have been moved to the Northumbria Specialist Emergency Care Hospital, in Cramlington, which opened in 2015, to deal with a \"very high demand\" in day-time admissions.\nA spokesman said it would be \"inappropriate\" to deploy staff back to the urgent care centres overnight at the current time.\nHe added: \"This is to ensure best use of precious staffing resources to deliver patient care where it is needed most.\"\nThe trust said since opening the Northumbria hospital in June 2015, activity overnight at the urgent care centres had been \"minimal\" with, on average, less than 10 overnight attendances a day across all three centres.\nThe spokesman added: \"We'd like to assure residents that this decision to temporarily extend the current arrangements at our urgent care centres has not been taken lightly.\n\"It was entirely correct for us to put in place the interim changes in the wake of services being extremely busy across the NHS. They have helped us successfully meet the high demand we continue to see, even now during the summer.\n\"As a result, it would simply not be the best use of our staff's time and expertise to deploy them back now.\"",
+    "reference": "Three emergency care units are to remain closed to overnight patients in an effort to keep \"precious staffing resources\" focused on daytime care.",
+    "prediction": "Three urgent care centres in Northumberland are to remain closed overnight for a further month, the NHS has said.",
+    "entities": [
+      {
+        "ent": "a further month",
+        "type": "DATE",
+        "start": 79,
+        "end": 94,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 8.253420674009249e-06,
+        "posterior_prob": 0.0017206646734848619
+      }
+    ]
+  },
+  {
+    "source": "The units in North Tyneside and Northumberland have been shut between midnight and 08:00 since December.\nOvernight emergencies have been diverted to the recently-opened Northumbria Hospital in Cramlington.\nThe closures at North Tyneside, Hexham and Wansbeck hospitals, will continue for a further three months.\nThe Northumbria Healthcare NHS Foundation Trust said the impact on patients had been minimal as the units were underused at night.\nStaff from the units have been moved to the Northumbria Specialist Emergency Care Hospital, in Cramlington, which opened in 2015, to deal with a \"very high demand\" in day-time admissions.\nA spokesman said it would be \"inappropriate\" to deploy staff back to the urgent care centres overnight at the current time.\nHe added: \"This is to ensure best use of precious staffing resources to deliver patient care where it is needed most.\"\nThe trust said since opening the Northumbria hospital in June 2015, activity overnight at the urgent care centres had been \"minimal\" with, on average, less than 10 overnight attendances a day across all three centres.\nThe spokesman added: \"We'd like to assure residents that this decision to temporarily extend the current arrangements at our urgent care centres has not been taken lightly.\n\"It was entirely correct for us to put in place the interim changes in the wake of services being extremely busy across the NHS. They have helped us successfully meet the high demand we continue to see, even now during the summer.\n\"As a result, it would simply not be the best use of our staff's time and expertise to deploy them back now.\"",
+    "reference": "Three emergency care units are to remain closed to overnight patients in an effort to keep \"precious staffing resources\" focused on daytime care.",
+    "prediction": "Northumbria's urgent care centres are to remain closed overnight for a further six months, the NHS has said.",
+    "entities": [
+      {
+        "ent": "a further six months",
+        "type": "DATE",
+        "start": 69,
+        "end": 89,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 5.087439149065176e-06,
+        "posterior_prob": 0.035151418298482895
+      }
+    ]
+  },
+  {
+    "source": "The units in North Tyneside and Northumberland have been shut between midnight and 08:00 since December.\nOvernight emergencies have been diverted to the recently-opened Northumbria Hospital in Cramlington.\nThe closures at North Tyneside, Hexham and Wansbeck hospitals, will continue for a further three months.\nThe Northumbria Healthcare NHS Foundation Trust said the impact on patients had been minimal as the units were underused at night.\nStaff from the units have been moved to the Northumbria Specialist Emergency Care Hospital, in Cramlington, which opened in 2015, to deal with a \"very high demand\" in day-time admissions.\nA spokesman said it would be \"inappropriate\" to deploy staff back to the urgent care centres overnight at the current time.\nHe added: \"This is to ensure best use of precious staffing resources to deliver patient care where it is needed most.\"\nThe trust said since opening the Northumbria hospital in June 2015, activity overnight at the urgent care centres had been \"minimal\" with, on average, less than 10 overnight attendances a day across all three centres.\nThe spokesman added: \"We'd like to assure residents that this decision to temporarily extend the current arrangements at our urgent care centres has not been taken lightly.\n\"It was entirely correct for us to put in place the interim changes in the wake of services being extremely busy across the NHS. They have helped us successfully meet the high demand we continue to see, even now during the summer.\n\"As a result, it would simply not be the best use of our staff's time and expertise to deploy them back now.\"",
+    "reference": "Three emergency care units are to remain closed to overnight patients in an effort to keep \"precious staffing resources\" focused on daytime care.",
+    "prediction": "Northumbria's urgent care centres are to remain closed at night for a further six weeks, the NHS has confirmed.",
+    "entities": [
+      {
+        "ent": "six weeks",
+        "type": "DATE",
+        "start": 78,
+        "end": 87,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.013117766939103603,
+        "posterior_prob": 0.0050562117248773575
+      }
+    ]
+  },
+  {
+    "source": "The company currently employs 500 people at premises in Glasgow, Robroyston, Livingston, Ayr, Clarkston, Hamilton, Lanark and Clydebank.\nThe expansion plans include new stores in Port Glasgow and Irvine, while other locations are \"in negotiation\".\nExisting stores in Clarkston, Ayr and Livingston will also be enlarged.\nThe family-owned business, which is currently celebrating its centenary, has forecast a turnover of between \u00c2\u00a325m and \u00c2\u00a330m in 2015.\nIts sells a wide range of products, including clothing and accessories, housewares, jewellery, watches, books, toys and confectionery.\nOwner Willie Watt said: \"Our business has changed dramatically since it first opened its doors in Glasgow's Sauchiehall Street, when the focus was exclusively on high-end ladies' fashions.\n\"We have evolved as a business and recognised that a retail offer including a wider range of great value products in a department store-style setting has greater appeal to today's consumer.\n\"We've seen positive growth in terms of both turnover and customer numbers, even in the recent recessionary period, and we've continued our expansion in terms of new store openings.\n\"My long-term plan is to have a total of 16 stores throughout Scotland, and we're constantly looking at new opportunities to secure ideal locations.\"",
+    "reference": "Retailer Watt Brothers has announced plans to create 350 new jobs by opening six new stores and expanding three others over the next few years.",
+    "prediction": "Fashion retailer The Watt Group has announced plans to create 500 new jobs as part of a major expansion of its stores across Scotland.",
+    "entities": [
+      {
+        "ent": "The Watt Group",
+        "type": "ORG",
+        "start": 17,
+        "end": 31,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 4.441326473259011e-10,
+        "posterior_prob": 0.0002780923678074032
+      }
+    ]
+  },
+  {
+    "source": "Councils in England are facing a \u00a31.1bn shortfall this year, on top of \"almost unendurable\" cuts since 2010, the Association of Directors of Adult Social Services has warned.\nFreezing care provider fees to save money was no long sustainable, it said.\nMinisters say extra money will help NHS and social care services work together.\nThe survey, which was completed by 147 directors of adult social services for councils in England, suggests that funding reductions to social care budgets have totalled \u00a34.6bn since 2010 - a 31% overall reduction.\nBudgets for adult social care - which provides practical support to people due to illness, disability, old age or a low income - will reduce by a further \u00a3500m in cash terms this year, it said.\n\"Taking the growth in numbers of older and disabled people into account, this means that an additional \u00a31.1bn would be needed to provide the same level of service as last year,\" the report warned.\nIt said some councils had made savings in the past by freezing fees paid to providers, but care providers were now also facing financial problems.\nSome companies - particularly those in southern England - are struggling to attract staff, amid increasing concern about the quality of care, it said.\n\"What is at stake is the continuing capacity of adult social care to sustain services to those in greatest need,\" ADASS president Ray James said.\n\"In virtually all our authorities, the number in need is growing, while the complexity of their needs is increasing.\"\nADASS called for the government to \"protect essential care and support services to the most vulnerable members of our community\".\nBut a government spokesman said the survey \"ignores\" a commitment to invest \u00a310bn in health services that are being \"joined up\" with social care, by 2020.\nThe BBC has launched an online guide to the care system for the over-65s. The \"care calculator\" covers residential care and the support provided in people's own homes, for tasks such as washing and dressing.\nUsers can submit their postcode and find out how much each service costs where they live in the UK.\nThere is also a dedicated BBC Cost of Care website, with news stories, analysis and video.\nThe spokesman said: \"Increasing budgets isn't the only solution. By working innovatively and joining up health and social care we can improve care and also save money.\"\nHowever, Councillor Izzi Seccombe, from the Local Government Association (LGA), said adult social care services were facing \"enormous pressures\" due to \"insufficient funding, growing demand and escalating costs\".\n\"We have long warned that investing in the NHS whilst social care budgets are under continual pressure is simply a false economy.\n\"It is social care services that support elderly and vulnerable people to maintain their independence, live in their own community and stay out of hospital longer,\" she added.\nCaroline Abrahams, charity director at Age UK, said the idea of a further \u00a31bn coming out of social care budgets was \"chilling\".\nSue Brown, vice chairman of the Care and Support Alliance - which represents 80 leading charities - said the figures \"confirm what we already know - that the care system is in worsening crisis\".\nShe said \"chronic underfunding\" of adult social care had seen \"dramatic year-on-year rationing of support, excluding hundreds of thousands of older and disabled people from the care they desperately need\".\nJanet Morrison, chief executive of the charity Independent Age, said: \"This worrying survey shows how the frail and elderly in our society are being hit by year on year cutbacks to council services.\"\n\"It's vital now more than ever that we have an honest debate about the true costs of providing social care, not just health care,\" she added.",
+    "reference": "Adult social care firms are struggling to hire, retain and train staff as a result of cuts to council budgets, a survey of senior officials suggests.",
+    "prediction": "Adult social care services in the UK will need an extra \u00a31.1bn to provide the same level of service as last year, a survey suggests.",
+    "entities": [
+      {
+        "ent": "an extra \u00a31.1bn",
+        "type": "MONEY",
+        "start": 47,
+        "end": 62,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.0001012106949929148,
+        "posterior_prob": 0.13248932361602783
+      }
+    ]
+  },
+  {
+    "source": "Six documents taken from an old account belonging to Mr Brennan were published by the anti-secrecy group WikiLeaks.\nThe CIA said there was \"no indication\" that anything classified was released.\nBut the documents do include a draft security clearance application containing personal information.\nThey appear to all date to 2009, when Mr Brennan was seeking security clearance while applying for a job as a White House counterterrorism adviser.\nHe was working in the private sector at the time, having already spent 25 years working for the CIA between 1980 and 2005.\nA high-school student claimed he was responsible for hacking the AOL account, telling Nthe New York Post he was protesting against US foreign policy.\nThe boy's Twitter account, which says he is 13, has published redacted images of what appears to be government information.\nThe documents published by Wikileaks include a draft on national security challenges said to have been created in 2007.\nThe final, unfinished paragraph is headed \"Damaging Leaks of Classified Information\".\nA 2008 letter about interrogation methods is also included, appearing to be from the vice-chairman of the Senate Select Committee on Intelligence to his fellow board members.\nWikileaks said it would release more documents \"over the coming days\".\nThe FBI and the Secret Service are investigating the hacking. The CIA stressed that none of the documents released so far were classified.\n\"In fact, they appear to be documents that a private citizen with national security interests and expertise would be expected to possess,\" a statement said.\nHigh-profile leaks including a wealth of diplomatic cables from Wikileaks have dogged the US government in recent years.\nThe use of private email has become a major issue in recent months for White House hopeful Hillary Clinton, since it emerged that she had operated a private account while secretary of state.\nMr Brennan became director of the CIA in 2013, having spent four years as assistant to the president for homeland security and counterterrorism.",
+    "reference": "The CIA has condemned the hacking of director John Brennan's personal email account, describing it as a \"crime\" carried out with \"malicious intent\".",
+    "prediction": "The US Central Intelligence Agency (CIA) has said it is investigating claims that its director John Brennan's personal email account was hacked.",
+    "entities": [
+      {
+        "ent": "The US Central Intelligence Agency",
+        "type": "ORG",
+        "start": 0,
+        "end": 34,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 3.438083922446822e-06,
+        "posterior_prob": 2.744256562436931e-06
+      }
+    ]
+  },
+  {
+    "source": "The 36-year-old was taken to a London hospital in a critical condition at about 03:45 after he became unwell at an address in Carshalton Road, Mitcham.\nHe died in hospital shortly after 07:00 GMT and his next of kin have been informed.\nA police spokesperson said they were treating the death as \"unexplained\" and enquiries at the home were ongoing.\nIt is not believed that any other person was involved.\nThe spokesperson added that there was \"no evidence to suggest that the incident is linked to extremism or terrorism\".\nSurrounding roads were closed as emergency services including fire engines carrying specialist chemical detection equipment attended the scene.\nHowever, these have since reopened.",
+    "reference": "A man has died after he \"came into contact with chemicals\" at a house in south London, police said.",
+    "prediction": "A man has died after suffering a suspected chemical poisoning at a house in north London.",
+    "entities": [
+      {
+        "ent": "north London",
+        "type": "GPE",
+        "start": 76,
+        "end": 88,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.000236984618823044,
+        "posterior_prob": 0.0005507823079824448
+      }
+    ]
+  },
+  {
+    "source": "Real politics will inevitably mean concession and compromise after a campaign in which both sides seemed at times to suggest it was a choice between Utopia and Armageddon.\nPoliticians on the Leave side have already candidly admitted that some of their supporters will be 'disappointed' by the deal that emerges.\nWhat some heard as promises may prove to be \"just a series of possibilities,\" as Iain Duncan Smith put it yesterday.\nOsborne: UK in a position of strength\nCorbyn vows to fight for leadership\nEU co-operation to 'intensify' - Johnson\nFollow the latest developments on our live page\nUK's EU referendum: All you need to know\nEqually, on the Remain side there is palpable dismay bordering on despair, but politicians must work hard to ensure that frustration and disillusionment can be quickly soothed.\nBritain has a tough job on and it will be far harder in a climate of bitterness and division.\nThe campaign itself was unedifying to many. The standing of politicians was frighteningly low before the referendum and one suspects their stock will not have been raised by the events of the last few months.\nThe institutions and public servants whose expertise and motives were called into question at times during the campaign are going to be key to guiding Britain through the turbulent times ahead.\nThe British people must have confidence in their system of governance and their precious democracy at this uncertain time.\nWe have proved to be remarkably resilient in the past. We will need the same grit, determination and courage now.\nEmotions are running high on both sides of the argument and there will be a need for a calm head at the steering wheel as Britain navigates the \"bumps in the road\".\nOffering comfort to foreign-born residents that they will be treated fairly and protected from abuse is essential. The same goes for British ethnic minorities.\nAfter all the accusations of lying during the campaign, the public must believe now they are being given honest counsel.\nThe process just beginning will not yield speedy benefits. Some will suggest that the very people who are charged with guiding Britain out of the EU are trying to undermine it.\nThere will be anger and bitterness. It will need to be managed carefully.",
+    "reference": "Just as the Chancellor spent the morning trying to calm the City, so there will be a need to manage the expectations of the country.",
+    "prediction": "It will not be easy for the UK to come to terms with its decision to leave the European Union, but it will be far harder to do so in a climate of bitterness and division.",
+    "entities": [
+      {
+        "ent": "the European Union",
+        "type": "ORG",
+        "start": 75,
+        "end": 93,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 5.2767907618544996e-05,
+        "posterior_prob": 0.8031983971595764
+      }
+    ]
+  },
+  {
+    "source": "Hernandez, 24, has signed a three-year deal, which the Tigers have the option of extending for a further 12 months.\nHull's previous record transfer outlay was the \u00a38m they paid Tottenham for midfielder Jake Livermore in June.\nThey also completed the signings of midfielders Mohamed Diame from West Ham and Gaston Ramirez from Southampton.\nHernandez has scored seven goals in 14 matches for Uruguay and made two appearances at the 2014 Fifa World Cup.\nTigers boss Steve Bruce said: \"Abel is a fantastic signing and highlights just how far the club has come in such a short space of time.\n\"He is an exciting talent and, like myself, I'm sure the supporters can't wait to see him in action.\"\nHernandez, who scored 14 goals in 28 appearances to help Palermo win promotion to Italy's Serie A last season, arrives following the \u00a312m sale of Shane Long to Southampton.\nHis signing takes Hull's summer spending beyond \u00a330m.\nBen Arfa, a 27-year-old France international winger, has spent the past three seasons on Tyneside, having joined the Magpies from Marseille in January 2011 following a successful loan spell.\n\"Hatem is a superb addition to the squad, and brings a lot of attacking flair,\" said manager Steve Bruce.\nBen Arfa made 86 appearances for Newcastle, scoring 14 goals.",
+    "reference": "Hull City have signed Uruguay striker Abel Hernandez from Palermo for a club-record \u00a310m fee, while Hatem Ben Arfa has joined on loan from Newcastle.",
+    "prediction": "Hull City have completed the signing of forward Abel Hernandez from Palermo and winger Hatem Ben Arfa from Newcastle United for a club record fee.",
+    "entities": [
+      {
+        "ent": "Newcastle United",
+        "type": "GPE",
+        "start": 107,
+        "end": 123,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.06280021369457245,
+        "posterior_prob": 0.5501506328582764
+      }
+    ]
+  },
+  {
+    "source": "In a series of Twitter posts addressed directly to Mr Maduro, Mr Almagro also called him a \"petty dictator\".\nMr Maduro accused the OAS chief earlier this week of being a CIA agent and a traitor himself.\nThe Venezuelan president has blamed his country's economic crisis on an axis of enemy forces co-ordinated from the US.\nDuring a three-hour long news conference on Tuesday, Mr Maduro had justified his declaration of a state of emergency by saying Venezuela was under attack from imperialist forces led by the CIA.\nHe then told journalists: \"Almagro, just give up. He has been a traitor for a long time... At some point I will tell his story, I know his secrets. The Americans, the CIA, have played a master move using Almagro as their agent.\"\nMr Almagro, who before leading the OAS was the foreign minister of his native Uruguay, had already clashed with Mr Maduro last year after he called him \"rubbish\".\nMr Almagro had responded on that occasion with an eight-page open letter, saying he would be \"rubbish\" if he ignored the plight of the Venezuelan people.\nHis Twitter posts this week were both more concise and more direct.\nLinking to his open letter to Mr Maduro, Mr Almagro said: @NicolasMaduro I'm not a traitor either to my ideas or my principles BUT YOU ARE A TRAITOR to your people.\nIn a series of 12 tweets, he also told the Venezuelan president that \"you will NEVER be able to undo so much suffering, intimidation, misery and anguish you've created for your people\".\nHe also said Mr Maduro would \"NEVER be able to bring back to life the children who've died because of lack of medicine\".\nVenezuelan doctors say a shortage of essential medicine has reached a crisis point.\nMr Almagro also urged Mr Maduro to allow a recall referendum to go ahead.\nOpposition politicians have handed in a petition with 1.85 million signatures to the electoral authorities requesting a referendum be held to recall Mr Maduro from office.\nBut Mr Maduro's deputy, Vice-President Aristobulo Isturiz, on Sunday ruled out such a referendum, saying the signatures were \"fraudulent\".\nMr Almagro said that not letting the referendum go ahead made Mr Maduro \"another petty dictator\".\nWhile President Maduro did not answer Mr Almagro's tweets directly, Venezuelan Foreign Minister Delcy Rodriguez did.\nShe wrote, \"Mr Almagro, every time you make a statement you express your hatred against Venezuela and its legitimate authorities. You are part of the imperialist detritus.\"\n\"You only repeat the scripted words which your imperialist masters dictate to you\".\n\"You will never give orders to Venezuela!\"\nThe former president of Uruguay, Jose Mujica, has also commented on the row between Mr Almagro, who served as Mr Mujica's foreign minister, and President Maduro.\nAsked what he made of the bitter exchange, he said using a popular Spanish saying that Mr Maduro was \"crazy as a goat\".\n\"They're all crazy in Venezuela, they call each other all sorts of things but they're not going to fix anything this way.\"\nWhile Mr Mujica is known for his direct and outspoken manner his words are damaging to Mr Maduro, who has always praised the former left-wing president as a \"comrade\".",
+    "reference": "The head of the Organization of American States (OAS), Luis Almagro, has accused the Venezuelan President Nicolas Maduro of being \"a traitor\".",
+    "prediction": "The head of the Organization of American States (OAS), Luis Almagro, has accused Venezuelan President Nicolas Maduro of being a traitor.",
+    "entities": [
+      {
+        "ent": "the Organization of American States",
+        "type": "ORG",
+        "start": 12,
+        "end": 47,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.7619688510894775,
+        "posterior_prob": 0.24272537231445312
+      }
+    ]
+  },
+  {
+    "source": "Anthony Scouler, 55, used seven bank accounts to hide profits of more than \u00c2\u00a3100,000, Exeter Crown Court heard.\nHe also used fake identities to get credit cards to pay for high-tech growing equipment.\nScouler of Barton Road in Bideford, Devon, admitted supply, production and personal possession of cannabis and having a shotgun without a certificate.\nHe denied money laundering but was found guilty of eight out of 14 counts by a jury at Exeter Crown Court in February.\nPolice raided his furniture shop in Boutport Street, Barnstaple, in 2012 and found 112 plants.\nRecorder Michael Fitton said Scouler had grown cannabis on a \"moderate but commercial scale...producing two or three crops a year\" from 2010.\n\"You had a significant role. It may be you had the guidance of others and were doing this at the invitation of others but it was your enterprise under your control,\" he said.\n\"I also have to have regard for the dishonesty, the abstraction of electricity, the fraud and the use of specialist equipment. I accept you were of good character and under financial pressure.\"\nMr Richard Crabb, defending, said Scouler had been drawn into growing drugs by others as the result of financial problems caused by his business failing during the recession.",
+    "reference": "A shop owner who turned his failing business into a cannabis factory has been jailed for four-and-a-half years.",
+    "prediction": "A furniture shop owner has been jailed for eight years for running a \"significant\" cannabis farm.",
+    "entities": [
+      {
+        "ent": "eight years",
+        "type": "DATE",
+        "start": 43,
+        "end": 54,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.032636966556310654,
+        "posterior_prob": 0.07936439663171768
+      }
+    ]
+  },
+  {
+    "source": "Anthony Scouler, 55, used seven bank accounts to hide profits of more than \u00c2\u00a3100,000, Exeter Crown Court heard.\nHe also used fake identities to get credit cards to pay for high-tech growing equipment.\nScouler of Barton Road in Bideford, Devon, admitted supply, production and personal possession of cannabis and having a shotgun without a certificate.\nHe denied money laundering but was found guilty of eight out of 14 counts by a jury at Exeter Crown Court in February.\nPolice raided his furniture shop in Boutport Street, Barnstaple, in 2012 and found 112 plants.\nRecorder Michael Fitton said Scouler had grown cannabis on a \"moderate but commercial scale...producing two or three crops a year\" from 2010.\n\"You had a significant role. It may be you had the guidance of others and were doing this at the invitation of others but it was your enterprise under your control,\" he said.\n\"I also have to have regard for the dishonesty, the abstraction of electricity, the fraud and the use of specialist equipment. I accept you were of good character and under financial pressure.\"\nMr Richard Crabb, defending, said Scouler had been drawn into growing drugs by others as the result of financial problems caused by his business failing during the recession.",
+    "reference": "A shop owner who turned his failing business into a cannabis factory has been jailed for four-and-a-half years.",
+    "prediction": "A furniture shop owner has been jailed for seven years for running a \"significant\" cannabis farm.",
+    "entities": [
+      {
+        "ent": "seven years",
+        "type": "DATE",
+        "start": 43,
+        "end": 54,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.03630988672375679,
+        "posterior_prob": 0.0916583389043808
+      }
+    ]
+  },
+  {
+    "source": "Anthony Scouler, 55, used seven bank accounts to hide profits of more than \u00c2\u00a3100,000, Exeter Crown Court heard.\nHe also used fake identities to get credit cards to pay for high-tech growing equipment.\nScouler of Barton Road in Bideford, Devon, admitted supply, production and personal possession of cannabis and having a shotgun without a certificate.\nHe denied money laundering but was found guilty of eight out of 14 counts by a jury at Exeter Crown Court in February.\nPolice raided his furniture shop in Boutport Street, Barnstaple, in 2012 and found 112 plants.\nRecorder Michael Fitton said Scouler had grown cannabis on a \"moderate but commercial scale...producing two or three crops a year\" from 2010.\n\"You had a significant role. It may be you had the guidance of others and were doing this at the invitation of others but it was your enterprise under your control,\" he said.\n\"I also have to have regard for the dishonesty, the abstraction of electricity, the fraud and the use of specialist equipment. I accept you were of good character and under financial pressure.\"\nMr Richard Crabb, defending, said Scouler had been drawn into growing drugs by others as the result of financial problems caused by his business failing during the recession.",
+    "reference": "A shop owner who turned his failing business into a cannabis factory has been jailed for four-and-a-half years.",
+    "prediction": "A furniture shop owner has been jailed for six years after being found guilty of money laundering and growing cannabis.",
+    "entities": [
+      {
+        "ent": "six years",
+        "type": "DATE",
+        "start": 43,
+        "end": 52,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.03584657981991768,
+        "posterior_prob": 0.07005049288272858
+      }
+    ]
+  },
+  {
+    "source": "The Orlando City midfielder, 34, will replace Bayern Munich's Douglas Costa, who was removed from the squad because of an injury to his left thigh.\nEx-AC Milan and Real Madrid player Kaka has been a regular in coach Dunga's squads, without getting much game time.\nHe has won 91 caps and scored 29 goals, but has only played 60 minutes for his country in three years.\nKaka is the second player to be added to the squad because of injury, with Benfica's Jonas replacing Santos striker Ricardo Oliveira.\nBrazil have been drawn in Group B with Ecuador, Haiti and Peru for the tournament, which is staging a special 100th anniversary edition.\nSubscribe to the BBC Sport newsletter to get our pick of news, features and video sent to your inbox.",
+    "reference": "Kaka has been called up to the Brazil squad for next month's Copa America in the United States.",
+    "prediction": "Kaka has been called up to the Brazil squad for the Copa America next month.",
+    "entities": [
+      {
+        "ent": "the Copa America",
+        "type": "ORG",
+        "start": 48,
+        "end": 64,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.07767648249864578,
+        "posterior_prob": 0.03291173279285431
+      }
+    ]
+  },
+  {
+    "source": "The Orlando City midfielder, 34, will replace Bayern Munich's Douglas Costa, who was removed from the squad because of an injury to his left thigh.\nEx-AC Milan and Real Madrid player Kaka has been a regular in coach Dunga's squads, without getting much game time.\nHe has won 91 caps and scored 29 goals, but has only played 60 minutes for his country in three years.\nKaka is the second player to be added to the squad because of injury, with Benfica's Jonas replacing Santos striker Ricardo Oliveira.\nBrazil have been drawn in Group B with Ecuador, Haiti and Peru for the tournament, which is staging a special 100th anniversary edition.\nSubscribe to the BBC Sport newsletter to get our pick of news, features and video sent to your inbox.",
+    "reference": "Kaka has been called up to the Brazil squad for next month's Copa America in the United States.",
+    "prediction": "Kaka has been called up to the Brazil squad for the Copa America in Chile in June.",
+    "entities": [
+      {
+        "ent": "Chile",
+        "type": "GPE",
+        "start": 68,
+        "end": 73,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.24601642787456512,
+        "posterior_prob": 0.04855876788496971
+      },
+      {
+        "ent": "June",
+        "type": "DATE",
+        "start": 77,
+        "end": 81,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.027916664257645607,
+        "posterior_prob": 0.20976869761943817
+      }
+    ]
+  },
+  {
+    "source": "4 May 2016 Last updated at 17:39 BST\nThe way players navigate the 3D levels in Sea Hero Quest will be anonymously tracked and sent to the researchers.\nUnderstanding how people navigate 3D environments is important because the skill is often one of the first lost by people who have dementia.\nResearchers say the game could generate an unprecedented amount of data.\nRead the full story: Mobile game 'helps dementia research'",
+    "reference": "Dementia researchers have developed a video game that could lead to the development of early diagnostic tests for the disease.",
+    "prediction": "A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol.",
+    "entities": [
+      {
+        "ent": "the University of Bristol",
+        "type": "ORG",
+        "start": 84,
+        "end": 109,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0033094396349042654,
+        "posterior_prob": 0.03768283873796463
+      }
+    ]
+  },
+  {
+    "source": "4 May 2016 Last updated at 17:39 BST\nThe way players navigate the 3D levels in Sea Hero Quest will be anonymously tracked and sent to the researchers.\nUnderstanding how people navigate 3D environments is important because the skill is often one of the first lost by people who have dementia.\nResearchers say the game could generate an unprecedented amount of data.\nRead the full story: Mobile game 'helps dementia research'",
+    "reference": "Dementia researchers have developed a video game that could lead to the development of early diagnostic tests for the disease.",
+    "prediction": "A mobile game designed to help people with dementia is to be used by researchers at the University of Oxford.",
+    "entities": [
+      {
+        "ent": "the University of Oxford",
+        "type": "ORG",
+        "start": 84,
+        "end": 108,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.004748421721160412,
+        "posterior_prob": 0.011359068565070629
+      }
+    ]
+  },
+  {
+    "source": "4 May 2016 Last updated at 17:39 BST\nThe way players navigate the 3D levels in Sea Hero Quest will be anonymously tracked and sent to the researchers.\nUnderstanding how people navigate 3D environments is important because the skill is often one of the first lost by people who have dementia.\nResearchers say the game could generate an unprecedented amount of data.\nRead the full story: Mobile game 'helps dementia research'",
+    "reference": "Dementia researchers have developed a video game that could lead to the development of early diagnostic tests for the disease.",
+    "prediction": "A mobile game designed to help people with dementia is to be used by researchers at the University of Cambridge.",
+    "entities": [
+      {
+        "ent": "the University of Cambridge",
+        "type": "ORG",
+        "start": 84,
+        "end": 111,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.006027176510542631,
+        "posterior_prob": 0.018592974171042442
+      }
+    ]
+  },
+  {
+    "source": "4 May 2016 Last updated at 17:39 BST\nThe way players navigate the 3D levels in Sea Hero Quest will be anonymously tracked and sent to the researchers.\nUnderstanding how people navigate 3D environments is important because the skill is often one of the first lost by people who have dementia.\nResearchers say the game could generate an unprecedented amount of data.\nRead the full story: Mobile game 'helps dementia research'",
+    "reference": "Dementia researchers have developed a video game that could lead to the development of early diagnostic tests for the disease.",
+    "prediction": "A mobile game designed to help people with dementia is to be used by researchers at the University of Manchester.",
+    "entities": [
+      {
+        "ent": "the University of Manchester",
+        "type": "ORG",
+        "start": 84,
+        "end": 112,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.002839029999449849,
+        "posterior_prob": 0.008891237899661064
+      }
+    ]
+  },
+  {
+    "source": "The fire started at South Wales Wood Recycling in Heol Llan, Coity, just before 03:30 BST on Monday.\nFirefighters from Pencoed and Bridgend have isolated the burning material and they will resume work on Tuesday.\nSouth Wales Wood Recycling said they were working around the clock to help stop the blaze.\nIn a statement the company said the blaze had affected an estimated 1,000-2,000 tonnes of recycled wood chip.\nThe cause of the fire is not yet know, but the company said the \"circumstances were suspicious\".\nNatural Resources Wales officials are also at the scene in case of any environmental impact.",
+    "reference": "Firefighters have been battling a blaze at a recycling business in Bridgend after about 2,000 tonnes of wood chips set on fire.",
+    "prediction": "About 1,000 tonnes of wood chip has been destroyed in a fire at a recycling plant in Bridgend county.",
+    "entities": [
+      {
+        "ent": "About 1,000 tonnes",
+        "type": "QUANTITY",
+        "start": 0,
+        "end": 18,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 3.416302796210857e-09,
+        "posterior_prob": 7.875523237999005e-07
+      }
+    ]
+  },
+  {
+    "source": "The France midfielder has accepted a violent conduct charge for the incident during Saturday's goalless draw.\nSissoko, 27, apologised but was charged by the Football Association. Spurs will not appeal against the decision.\nHis suspension will include Tuesday's EFL Cup tie at Liverpool, plus league games against Leicester and Arsenal.\nThe FA said the incident was missed by match officials.\n\"I need to say the elbow was in the face of Arter and it is clear,\" Spurs manager Mauricio Pochettino said on Monday.\n\"We are in a period where we need all the squad, all the players to compete. It's difficult now because he is a player who was in our plans to play tomorrow, so we have to change a little bit.\"\nSpeaking to Match of the Day after Saturday's game, Arter said he was happy to accept Sissoko's explanation that the contact was accidental.\nHe said: \"I never want to see a player get into trouble if they didn't mean to. Sissoko apologised. I'm happy to move on from it.\"\nMedia playback is not supported on this device",
+    "reference": "Tottenham's Moussa Sissoko will be banned for three matches for elbowing Bournemouth's Harry Arter, missing the north London derby with Arsenal.",
+    "prediction": "Tottenham midfielder Moussa Sissoko has been banned for four games for an elbow to the face of Stoke's Harry Arter.",
+    "entities": [
+      {
+        "ent": "Stoke",
+        "type": "GPE",
+        "start": 95,
+        "end": 100,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.11674323678016663,
+        "posterior_prob": 0.09133501350879669
+      }
+    ]
+  },
+  {
+    "source": "The France midfielder has accepted a violent conduct charge for the incident during Saturday's goalless draw.\nSissoko, 27, apologised but was charged by the Football Association. Spurs will not appeal against the decision.\nHis suspension will include Tuesday's EFL Cup tie at Liverpool, plus league games against Leicester and Arsenal.\nThe FA said the incident was missed by match officials.\n\"I need to say the elbow was in the face of Arter and it is clear,\" Spurs manager Mauricio Pochettino said on Monday.\n\"We are in a period where we need all the squad, all the players to compete. It's difficult now because he is a player who was in our plans to play tomorrow, so we have to change a little bit.\"\nSpeaking to Match of the Day after Saturday's game, Arter said he was happy to accept Sissoko's explanation that the contact was accidental.\nHe said: \"I never want to see a player get into trouble if they didn't mean to. Sissoko apologised. I'm happy to move on from it.\"\nMedia playback is not supported on this device",
+    "reference": "Tottenham's Moussa Sissoko will be banned for three matches for elbowing Bournemouth's Harry Arter, missing the north London derby with Arsenal.",
+    "prediction": "Tottenham midfielder Moussa Sissoko has been banned for three games for an elbow to the face of Harry Arter.",
+    "entities": [
+      {
+        "ent": "three",
+        "type": "CARDINAL",
+        "start": 56,
+        "end": 61,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.22703467309474945,
+        "posterior_prob": 0.07533508539199829
+      }
+    ]
+  },
+  {
+    "source": "The France midfielder has accepted a violent conduct charge for the incident during Saturday's goalless draw.\nSissoko, 27, apologised but was charged by the Football Association. Spurs will not appeal against the decision.\nHis suspension will include Tuesday's EFL Cup tie at Liverpool, plus league games against Leicester and Arsenal.\nThe FA said the incident was missed by match officials.\n\"I need to say the elbow was in the face of Arter and it is clear,\" Spurs manager Mauricio Pochettino said on Monday.\n\"We are in a period where we need all the squad, all the players to compete. It's difficult now because he is a player who was in our plans to play tomorrow, so we have to change a little bit.\"\nSpeaking to Match of the Day after Saturday's game, Arter said he was happy to accept Sissoko's explanation that the contact was accidental.\nHe said: \"I never want to see a player get into trouble if they didn't mean to. Sissoko apologised. I'm happy to move on from it.\"\nMedia playback is not supported on this device",
+    "reference": "Tottenham's Moussa Sissoko will be banned for three matches for elbowing Bournemouth's Harry Arter, missing the north London derby with Arsenal.",
+    "prediction": "Tottenham midfielder Moussa Sissoko has been banned for six games for an elbow to Harry Arter's face.",
+    "entities": [
+      {
+        "ent": "six",
+        "type": "CARDINAL",
+        "start": 56,
+        "end": 59,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.04468626528978348,
+        "posterior_prob": 0.12465716153383255
+      }
+    ]
+  },
+  {
+    "source": "About 50 arrived in the city in May and the families have spent the last three months settling in to their new lives.\nA total of 98 refugees have now arrived in Northern Ireland since the conflict. The first group of Syrian refugees arrived in December 2015.\nThe war in Syria has claimed the lives of more than 250,000 people.\nSome of the refugees in Derry were at the North West Regional College on Tuesday to find out more about learning courses.\nBayan Khello, 18, had to leave many of her family behind including her brother who is currently in Germany.\nBayan spoke to BBC Radio Foyle through an interpreter.\n\"I still have family in Turkey and Aleppo, the sons of my cousin are still there, we have put in an application to have our family unified here.\n\"My uncle and my cousin were killed in the war. My cousin was going back from his work when a sniper shot him in the chest. That was one of my worst days,\" she said.\nBayan, who wears a free Syria wristband in the colours of her native country, said she did not want to leave her home.\n\"I didn't want to leave Aleppo, I wasn't eating for two months. Then my father told me 'We have to live our life now, we have to make a new start'.\n\"I saw houses knocked down with children underneath, its time to end this war, its enough.\"\nBayan, who has a degree in accountancy, said she does not yet know what kind of life she will have in Northern Ireland, but she wants to study hard and learn English.\nYasser Al Satton left his home in Syria after chemical weapons were used in the area.\n\"Within the last month the house of one my relations was bombed and ten people were killed.\n\"Everything that comes to your mind, we lived it and we saw it. One of my relation's lost both of his hands when a bomb exploded.\n\"If we had hope that the war would end we would have stayed but I don't believe the war will end,\" he said.\nYasser said that he was adjusting to his new life in the North West very well.\nA particular highlight was how friendly the people of Derry have been.\n\"Everybody says: 'Hello, how are you, how are you doing, what's the craic?\" he added.",
+    "reference": "A group of Syrian refugees living in Londonderry have spoken for the first time about what life was like in their war-torn country.",
+    "prediction": "The second group of Syrian refugees have arrived in Londonderry.",
+    "entities": [
+      {
+        "ent": "second",
+        "type": "ORDINAL",
+        "start": 4,
+        "end": 10,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0002694621216505766,
+        "posterior_prob": 0.7907263040542603
+      }
+    ]
+  },
+  {
+    "source": "Pictures of men kissing the figure, holding her hand and touching her chest and crotch have gone viral on Facebook and other social media.\nMalaysia is a Muslim-majority country which has seen religious conservatism on the rise in recent years.\nShell said the acts went against local culture and its own values.\nThe energy giant, which has more than 950 outlets in Malaysia, said it would not condone the \"distasteful and suggestive acts\", which it said were \"disrespectful\".\n\"We urge netizens and members of the public to refrain from sharing these images further\", it added, criticising the \"extreme behaviour\" of the men,\nThe adverts featuring a 25-year-old female employee, dressed in a red T-shirt, black trousers and a black headscarf.\nThe woman told local paper The Star that she felt \"humiliated\" by the images.\n\"They may just be joking, but I feel humiliated because that is still myself although it is just an image,\" she said.\nOne man who posted a four-minute video on Facebook of himself kissing the cardboard cutout has reportedly apologised.\n\"I let excitement get the better of me,\" he told a Malaysian news outlet.",
+    "reference": "Shell is removing life-sized cardboard cutouts of a female employee from all of its Malaysian petrol stations after \"distasteful\" images appeared online.",
+    "prediction": "Royal Dutch Shell has apologised after a cardboard cutout of a female employee appeared in one of its adverts in Malaysia.",
+    "entities": [
+      {
+        "ent": "Royal Dutch Shell",
+        "type": "ORG",
+        "start": 0,
+        "end": 17,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 8.284156693960654e-10,
+        "posterior_prob": 5.094964308227645e-06
+      }
+    ]
+  },
+  {
+    "source": "Nine men were arrested over a pitch invasion and flares being thrown during City's 3-0 loss at Sixfields.\nThe club has said that the \"repeated disruptions\" were \"unacceptable\".\nA Sky Blue Trust statement said: \"We do not condone anti-social and illegal acts such as the throwing of smoke bombs and multiple pitch invasions.\"\nThe statement continued: \"We do understand, however, that it was entirely the result of frustration and desperation and that many supporters are simply at the end of their tethers feeling powerless and ignored.\n\"While peaceful protests and petitions have attracted national attention and sympathy, they have seemingly been ignored by Sisu and [chairman] Tim Fisher and this once great club is in now in total disarray and turmoil.\n\"The scenes were ugly but borne of desperation and passion. The Trust urges all fans to keep any protests lawful and ensure these scenes are not be repeated.\"\nCoventry fans have held a number of protests against the club's owners this season, with December's EFL Trophy second round win over Crawley attracting a record-low home crowd.\nThe Sky Blues are without a League One victory since 1 November and have only won four times all season.",
+    "reference": "A Coventry City fans' trust says disruption at Saturday's defeat by Northampton was caused by \"desperation\" with the club's owners, Sisu.",
+    "prediction": "Coventry City's Supporters' Trust has said it does not condone anti-social and illegal acts following the pitch invasion during Saturday's League One defeat by Rochdale.",
+    "entities": [
+      {
+        "ent": "Supporters' Trust",
+        "type": "ORG",
+        "start": 16,
+        "end": 33,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.0002892369229812175,
+        "posterior_prob": 1.3905487321608234e-05
+      },
+      {
+        "ent": "Rochdale",
+        "type": "GPE",
+        "start": 160,
+        "end": 168,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 5.899546067666961e-06,
+        "posterior_prob": 0.0018124758498743176
+      }
+    ]
+  },
+  {
+    "source": "Nine men were arrested over a pitch invasion and flares being thrown during City's 3-0 loss at Sixfields.\nThe club has said that the \"repeated disruptions\" were \"unacceptable\".\nA Sky Blue Trust statement said: \"We do not condone anti-social and illegal acts such as the throwing of smoke bombs and multiple pitch invasions.\"\nThe statement continued: \"We do understand, however, that it was entirely the result of frustration and desperation and that many supporters are simply at the end of their tethers feeling powerless and ignored.\n\"While peaceful protests and petitions have attracted national attention and sympathy, they have seemingly been ignored by Sisu and [chairman] Tim Fisher and this once great club is in now in total disarray and turmoil.\n\"The scenes were ugly but borne of desperation and passion. The Trust urges all fans to keep any protests lawful and ensure these scenes are not be repeated.\"\nCoventry fans have held a number of protests against the club's owners this season, with December's EFL Trophy second round win over Crawley attracting a record-low home crowd.\nThe Sky Blues are without a League One victory since 1 November and have only won four times all season.",
+    "reference": "A Coventry City fans' trust says disruption at Saturday's defeat by Northampton was caused by \"desperation\" with the club's owners, Sisu.",
+    "prediction": "Coventry City's Supporters' Trust has said it does not condone anti-social and illegal acts following the pitch invasion during Saturday's League One defeat by Bristol Rovers.",
+    "entities": [
+      {
+        "ent": "Bristol Rovers",
+        "type": "ORG",
+        "start": 160,
+        "end": 174,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 3.366137025295757e-05,
+        "posterior_prob": 0.01713329553604126
+      }
+    ]
+  },
+  {
+    "source": "Nine men were arrested over a pitch invasion and flares being thrown during City's 3-0 loss at Sixfields.\nThe club has said that the \"repeated disruptions\" were \"unacceptable\".\nA Sky Blue Trust statement said: \"We do not condone anti-social and illegal acts such as the throwing of smoke bombs and multiple pitch invasions.\"\nThe statement continued: \"We do understand, however, that it was entirely the result of frustration and desperation and that many supporters are simply at the end of their tethers feeling powerless and ignored.\n\"While peaceful protests and petitions have attracted national attention and sympathy, they have seemingly been ignored by Sisu and [chairman] Tim Fisher and this once great club is in now in total disarray and turmoil.\n\"The scenes were ugly but borne of desperation and passion. The Trust urges all fans to keep any protests lawful and ensure these scenes are not be repeated.\"\nCoventry fans have held a number of protests against the club's owners this season, with December's EFL Trophy second round win over Crawley attracting a record-low home crowd.\nThe Sky Blues are without a League One victory since 1 November and have only won four times all season.",
+    "reference": "A Coventry City fans' trust says disruption at Saturday's defeat by Northampton was caused by \"desperation\" with the club's owners, Sisu.",
+    "prediction": "Coventry City's Supporters' Trust has said it does not condone anti-social and illegal acts following the pitch invasion during Saturday's League One defeat at Bristol City.",
+    "entities": [
+      {
+        "ent": "Bristol City",
+        "type": "GPE",
+        "start": 160,
+        "end": 172,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 1.6758087440393865e-05,
+        "posterior_prob": 0.005294551607221365
+      }
+    ]
+  },
+  {
+    "source": "Nine men were arrested over a pitch invasion and flares being thrown during City's 3-0 loss at Sixfields.\nThe club has said that the \"repeated disruptions\" were \"unacceptable\".\nA Sky Blue Trust statement said: \"We do not condone anti-social and illegal acts such as the throwing of smoke bombs and multiple pitch invasions.\"\nThe statement continued: \"We do understand, however, that it was entirely the result of frustration and desperation and that many supporters are simply at the end of their tethers feeling powerless and ignored.\n\"While peaceful protests and petitions have attracted national attention and sympathy, they have seemingly been ignored by Sisu and [chairman] Tim Fisher and this once great club is in now in total disarray and turmoil.\n\"The scenes were ugly but borne of desperation and passion. The Trust urges all fans to keep any protests lawful and ensure these scenes are not be repeated.\"\nCoventry fans have held a number of protests against the club's owners this season, with December's EFL Trophy second round win over Crawley attracting a record-low home crowd.\nThe Sky Blues are without a League One victory since 1 November and have only won four times all season.",
+    "reference": "A Coventry City fans' trust says disruption at Saturday's defeat by Northampton was caused by \"desperation\" with the club's owners, Sisu.",
+    "prediction": "Coventry City's Supporters' Trust has said it does not condone anti-social and illegal acts following the pitch invasion during Saturday's League One defeat by Bristol Roosters.",
+    "entities": [
+      {
+        "ent": "Bristol Roosters",
+        "type": "ORG",
+        "start": 160,
+        "end": 176,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 3.1910185604999697e-09,
+        "posterior_prob": 9.750945537234657e-06
+      }
+    ]
+  },
+  {
+    "source": "Nine men were arrested over a pitch invasion and flares being thrown during City's 3-0 loss at Sixfields.\nThe club has said that the \"repeated disruptions\" were \"unacceptable\".\nA Sky Blue Trust statement said: \"We do not condone anti-social and illegal acts such as the throwing of smoke bombs and multiple pitch invasions.\"\nThe statement continued: \"We do understand, however, that it was entirely the result of frustration and desperation and that many supporters are simply at the end of their tethers feeling powerless and ignored.\n\"While peaceful protests and petitions have attracted national attention and sympathy, they have seemingly been ignored by Sisu and [chairman] Tim Fisher and this once great club is in now in total disarray and turmoil.\n\"The scenes were ugly but borne of desperation and passion. The Trust urges all fans to keep any protests lawful and ensure these scenes are not be repeated.\"\nCoventry fans have held a number of protests against the club's owners this season, with December's EFL Trophy second round win over Crawley attracting a record-low home crowd.\nThe Sky Blues are without a League One victory since 1 November and have only won four times all season.",
+    "reference": "A Coventry City fans' trust says disruption at Saturday's defeat by Northampton was caused by \"desperation\" with the club's owners, Sisu.",
+    "prediction": "Coventry City's fans' trust has said it does not condone anti-social and illegal acts, following disturbances at this season's League One match against Leyton Orient.",
+    "entities": [
+      {
+        "ent": "Leyton Orient",
+        "type": "ORG",
+        "start": 152,
+        "end": 165,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 4.0356972021982074e-05,
+        "posterior_prob": 0.04602757841348648
+      }
+    ]
+  },
+  {
+    "source": "Gaiman's fantasy novel beat fellow National Book Award winners including Kate Atkinson and David Walliams.\nThe tale about a man returning to his childhood home for a funeral won the public vote from a shortlist of this year's 10 National Book Award winners.\nThe graphic novelist said he was \"amazed and thrilled\".\n\"I've never written a book before that was so close to my own heart - a story about memory and magic and the fear and danger of being a child,\" said Gaiman.\n\"I wasn't sure that anyone else would like it.\n\"I'm amazed and thrilled that so many other people have read it, loved it, and made their friends read it too.\n\"Winning a National Book Award was thrilling; discovering that the public have made The Ocean at the End of the Lane their Book of the Year is somewhere out beyond wonderful. Thank you to everyone who voted.\"\n'Dedication'\nGaiman's novel had already won in the Audiobook of the Year category.\nThe book secured the public vote from a shortlist including Gillian Flynn's bestseller Gone Girl, David Jason's My Life and schoolgirl Malala Yousafzai's I Am Malala to win the Book of the Year title.\nOnline voting for the title, the only book award chosen by readers, closed on 19 December.\nLast year's winner was EL James' raunchy blockbuster Fifty Shades of Grey, while Caitlin Moran's How To Be A Woman and David Nicholls' romantic novel One Day have also taken the prize.\nDame Mary Perkins, founder of the award's sponsors Specsavers, congratulated Gaiman on \"this fantastic award\".\n\"The competition was tough but to be chosen by members of the public as well as your industry peers truly is a tribute to hard work, dedication and creativity,\" she said.\nGaiman made his name writing graphic novels including The Sandman series and Coraline. He has penned two recent Doctor Who episodes featuring Matt Smith and is currently writing a prequel to The Sandman. A TV series of his book American Gods is in development.",
+    "reference": "Neil Gaiman's The Ocean at the End of the Lane has been voted 2013's Book of the Year, winning the public vote \"by a considerable margin\".",
+    "prediction": "Neil Gaiman's novel The Ocean at the End of the Lane has been named the UK's Book of the Year.",
+    "entities": [
+      {
+        "ent": "UK",
+        "type": "GPE",
+        "start": 72,
+        "end": 74,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.024842973798513412,
+        "posterior_prob": 0.9046176075935364
+      }
+    ]
+  },
+  {
+    "source": "Gaiman's fantasy novel beat fellow National Book Award winners including Kate Atkinson and David Walliams.\nThe tale about a man returning to his childhood home for a funeral won the public vote from a shortlist of this year's 10 National Book Award winners.\nThe graphic novelist said he was \"amazed and thrilled\".\n\"I've never written a book before that was so close to my own heart - a story about memory and magic and the fear and danger of being a child,\" said Gaiman.\n\"I wasn't sure that anyone else would like it.\n\"I'm amazed and thrilled that so many other people have read it, loved it, and made their friends read it too.\n\"Winning a National Book Award was thrilling; discovering that the public have made The Ocean at the End of the Lane their Book of the Year is somewhere out beyond wonderful. Thank you to everyone who voted.\"\n'Dedication'\nGaiman's novel had already won in the Audiobook of the Year category.\nThe book secured the public vote from a shortlist including Gillian Flynn's bestseller Gone Girl, David Jason's My Life and schoolgirl Malala Yousafzai's I Am Malala to win the Book of the Year title.\nOnline voting for the title, the only book award chosen by readers, closed on 19 December.\nLast year's winner was EL James' raunchy blockbuster Fifty Shades of Grey, while Caitlin Moran's How To Be A Woman and David Nicholls' romantic novel One Day have also taken the prize.\nDame Mary Perkins, founder of the award's sponsors Specsavers, congratulated Gaiman on \"this fantastic award\".\n\"The competition was tough but to be chosen by members of the public as well as your industry peers truly is a tribute to hard work, dedication and creativity,\" she said.\nGaiman made his name writing graphic novels including The Sandman series and Coraline. He has penned two recent Doctor Who episodes featuring Matt Smith and is currently writing a prequel to The Sandman. A TV series of his book American Gods is in development.",
+    "reference": "Neil Gaiman's The Ocean at the End of the Lane has been voted 2013's Book of the Year, winning the public vote \"by a considerable margin\".",
+    "prediction": "Neil Gaiman's The Ocean at the End of the Lane has won the National Book of the Year award.",
+    "entities": [
+      {
+        "ent": "the National Book of the Year",
+        "type": "WORK_OF_ART",
+        "start": 55,
+        "end": 84,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 2.3657490189066266e-08,
+        "posterior_prob": 0.05136209353804588
+      }
+    ]
+  },
+  {
+    "source": "Holdsworth, 47, beat takeover offers from banker Roger Tamraz and Bolton Wanderers Supporters' Trust.\nThe club, owned by Eddie Davies, are \u00a3172.9m in debt and have been trying to find a buyer for a number of months.\nThe Championship strugglers are scheduled in the High Court on Monday over a \u00a33m unpaid tax bill.\nIt is hoped the takeover will soon be completed as Wanderers must let the High Court know by 19 February if they are going to enter administration, and also prove they have funds to continue trading.\nFormer Wimbledon and Brentford forward Holdsworth spent six seasons at Bolton, scoring 52 goals in 188 appearances.\nBBC Radio Manchester also understands the sale of the Trotters' training ground at Euxton has yet to be finalised, with League One side Wigan making an approach.",
+    "reference": "Bolton Wanderers have given preferred bidder status to former striker Dean Holdsworth's Sports Shield consortium, reports BBC Radio Manchester.",
+    "prediction": "Bolton Wanderers have agreed a deal to sell the club to ex-Trotters striker Paul Holdsworth, BBC Radio Manchester understands.",
+    "entities": [
+      {
+        "ent": "Paul",
+        "type": "PERSON",
+        "start": 76,
+        "end": 80,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.035481687635183334,
+        "posterior_prob": 0.19889818131923676
+      }
+    ]
+  },
+  {
+    "source": "Holdsworth, 47, beat takeover offers from banker Roger Tamraz and Bolton Wanderers Supporters' Trust.\nThe club, owned by Eddie Davies, are \u00a3172.9m in debt and have been trying to find a buyer for a number of months.\nThe Championship strugglers are scheduled in the High Court on Monday over a \u00a33m unpaid tax bill.\nIt is hoped the takeover will soon be completed as Wanderers must let the High Court know by 19 February if they are going to enter administration, and also prove they have funds to continue trading.\nFormer Wimbledon and Brentford forward Holdsworth spent six seasons at Bolton, scoring 52 goals in 188 appearances.\nBBC Radio Manchester also understands the sale of the Trotters' training ground at Euxton has yet to be finalised, with League One side Wigan making an approach.",
+    "reference": "Bolton Wanderers have given preferred bidder status to former striker Dean Holdsworth's Sports Shield consortium, reports BBC Radio Manchester.",
+    "prediction": "Bolton Wanderers have agreed a deal to sell the club to ex-Trotters striker Gary Holdsworth, BBC Radio Manchester understands.",
+    "entities": [
+      {
+        "ent": "Gary",
+        "type": "PERSON",
+        "start": 76,
+        "end": 80,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.03804328665137291,
+        "posterior_prob": 0.029108259826898575
+      }
+    ]
+  },
+  {
+    "source": "Holdsworth, 47, beat takeover offers from banker Roger Tamraz and Bolton Wanderers Supporters' Trust.\nThe club, owned by Eddie Davies, are \u00a3172.9m in debt and have been trying to find a buyer for a number of months.\nThe Championship strugglers are scheduled in the High Court on Monday over a \u00a33m unpaid tax bill.\nIt is hoped the takeover will soon be completed as Wanderers must let the High Court know by 19 February if they are going to enter administration, and also prove they have funds to continue trading.\nFormer Wimbledon and Brentford forward Holdsworth spent six seasons at Bolton, scoring 52 goals in 188 appearances.\nBBC Radio Manchester also understands the sale of the Trotters' training ground at Euxton has yet to be finalised, with League One side Wigan making an approach.",
+    "reference": "Bolton Wanderers have given preferred bidder status to former striker Dean Holdsworth's Sports Shield consortium, reports BBC Radio Manchester.",
+    "prediction": "Bolton Wanderers have agreed a deal to sell the club to former striker Graham Holdsworth, BBC Radio Manchester understands.",
+    "entities": [
+      {
+        "ent": "Graham",
+        "type": "PERSON",
+        "start": 71,
+        "end": 77,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.005265688523650169,
+        "posterior_prob": 0.025688357651233673
+      }
+    ]
+  },
+  {
+    "source": "The horror starring Vera Farmiga and Patrick Wilson as paranormal investigators made $40.4m (\u00a328.5m).\nVideo game adaptation Warcraft came in second with $24.4m (\u00a317.2m) and crime caper Now You See Me 2 was at three, taking $23m (\u00a316.2m).\nTeenage Mutant Ninja Turtles dropped to four with $14.8m (\u00a310.4m).\nFollowing a spate of poor performing sequels such as The Huntsman: Winter's War, Alice Through the Looking Glass and Ride Along 2, The Conjuring 2 opened nearly on par with its 2013 original.\n\"There's seemingly been a spell cast over the second instalments and The Conjuring, I think, broke that spell,\" said Paul Dergarabedian, senior media analyst for Comscore.\n\"Just the overall quality won over the audience in a genre that's generally looked down upon from a critical perspective.''\nBig budget CGI extravaganza Warcraft, taken from the hit video game franchise, reportedly cost $160m (\u00a3112.8m) to make, so effectively bombed in the US financially as well as critically.\nHowever, it was a phenomenal success overseas, particularly in China where it made $156m (\u00a3110m) in its first five days, surpassing 2015's Avengers: Age of Ultron to set a new record for the biggest debut for a foreign release.\nThe game is particularly popular there, even spawning a theme park.\nThe magician crime caper Now You See Me 2, starring Jesse Eisenberg, Mark Ruffalo and Woody Harrelson, followed the disappointing trajectory of most recent sequels, dropping from its 2013 original opening debut of $29.4m (\u00a320.8) to $23m (\u00a316.2m).\nThe fifth Teenage Mutant Ninja Turtles movie, Out of the Shadows, fell to number four in only its second weekend.\nThe last movie in the franchise grossed nearly double in its opening weekend box office.\nRounding off the top five was X-Men: Apocalypse, taking $10m (\u00a37m) in a troubling third weekend.\nNext week sees the release of Pixar's Finding Nemo sequel, Finding Dory.",
+    "reference": "The Conjuring 2 has topped the North American box office chart in its first week of release, breaking a recent slump in success for movie sequels.",
+    "prediction": "The Conjuring 2 has topped the US and Canada box office for the second weekend in a row.",
+    "entities": [
+      {
+        "ent": "the second weekend in a row",
+        "type": "DATE",
+        "start": 60,
+        "end": 87,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0007166421855799854,
+        "posterior_prob": 0.05454447865486145
+      }
+    ]
+  },
+  {
+    "source": "The horror starring Vera Farmiga and Patrick Wilson as paranormal investigators made $40.4m (\u00a328.5m).\nVideo game adaptation Warcraft came in second with $24.4m (\u00a317.2m) and crime caper Now You See Me 2 was at three, taking $23m (\u00a316.2m).\nTeenage Mutant Ninja Turtles dropped to four with $14.8m (\u00a310.4m).\nFollowing a spate of poor performing sequels such as The Huntsman: Winter's War, Alice Through the Looking Glass and Ride Along 2, The Conjuring 2 opened nearly on par with its 2013 original.\n\"There's seemingly been a spell cast over the second instalments and The Conjuring, I think, broke that spell,\" said Paul Dergarabedian, senior media analyst for Comscore.\n\"Just the overall quality won over the audience in a genre that's generally looked down upon from a critical perspective.''\nBig budget CGI extravaganza Warcraft, taken from the hit video game franchise, reportedly cost $160m (\u00a3112.8m) to make, so effectively bombed in the US financially as well as critically.\nHowever, it was a phenomenal success overseas, particularly in China where it made $156m (\u00a3110m) in its first five days, surpassing 2015's Avengers: Age of Ultron to set a new record for the biggest debut for a foreign release.\nThe game is particularly popular there, even spawning a theme park.\nThe magician crime caper Now You See Me 2, starring Jesse Eisenberg, Mark Ruffalo and Woody Harrelson, followed the disappointing trajectory of most recent sequels, dropping from its 2013 original opening debut of $29.4m (\u00a320.8) to $23m (\u00a316.2m).\nThe fifth Teenage Mutant Ninja Turtles movie, Out of the Shadows, fell to number four in only its second weekend.\nThe last movie in the franchise grossed nearly double in its opening weekend box office.\nRounding off the top five was X-Men: Apocalypse, taking $10m (\u00a37m) in a troubling third weekend.\nNext week sees the release of Pixar's Finding Nemo sequel, Finding Dory.",
+    "reference": "The Conjuring 2 has topped the North American box office chart in its first week of release, breaking a recent slump in success for movie sequels.",
+    "prediction": "The Conjuring 2 has topped the US and Canada box office for the second week in a row.",
+    "entities": [
+      {
+        "ent": "the second week in a row",
+        "type": "DATE",
+        "start": 60,
+        "end": 84,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0029639292042702436,
+        "posterior_prob": 0.0013554790057241917
+      }
+    ]
+  },
+  {
+    "source": "The horror starring Vera Farmiga and Patrick Wilson as paranormal investigators made $40.4m (\u00a328.5m).\nVideo game adaptation Warcraft came in second with $24.4m (\u00a317.2m) and crime caper Now You See Me 2 was at three, taking $23m (\u00a316.2m).\nTeenage Mutant Ninja Turtles dropped to four with $14.8m (\u00a310.4m).\nFollowing a spate of poor performing sequels such as The Huntsman: Winter's War, Alice Through the Looking Glass and Ride Along 2, The Conjuring 2 opened nearly on par with its 2013 original.\n\"There's seemingly been a spell cast over the second instalments and The Conjuring, I think, broke that spell,\" said Paul Dergarabedian, senior media analyst for Comscore.\n\"Just the overall quality won over the audience in a genre that's generally looked down upon from a critical perspective.''\nBig budget CGI extravaganza Warcraft, taken from the hit video game franchise, reportedly cost $160m (\u00a3112.8m) to make, so effectively bombed in the US financially as well as critically.\nHowever, it was a phenomenal success overseas, particularly in China where it made $156m (\u00a3110m) in its first five days, surpassing 2015's Avengers: Age of Ultron to set a new record for the biggest debut for a foreign release.\nThe game is particularly popular there, even spawning a theme park.\nThe magician crime caper Now You See Me 2, starring Jesse Eisenberg, Mark Ruffalo and Woody Harrelson, followed the disappointing trajectory of most recent sequels, dropping from its 2013 original opening debut of $29.4m (\u00a320.8) to $23m (\u00a316.2m).\nThe fifth Teenage Mutant Ninja Turtles movie, Out of the Shadows, fell to number four in only its second weekend.\nThe last movie in the franchise grossed nearly double in its opening weekend box office.\nRounding off the top five was X-Men: Apocalypse, taking $10m (\u00a37m) in a troubling third weekend.\nNext week sees the release of Pixar's Finding Nemo sequel, Finding Dory.",
+    "reference": "The Conjuring 2 has topped the North American box office chart in its first week of release, breaking a recent slump in success for movie sequels.",
+    "prediction": "The Conjuring 2 has topped the US and Canada box office for the second time in three years.",
+    "entities": [
+      {
+        "ent": "three years",
+        "type": "DATE",
+        "start": 79,
+        "end": 90,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0003559111210051924,
+        "posterior_prob": 0.12914995849132538
+      }
+    ]
+  },
+  {
+    "source": "The horror starring Vera Farmiga and Patrick Wilson as paranormal investigators made $40.4m (\u00a328.5m).\nVideo game adaptation Warcraft came in second with $24.4m (\u00a317.2m) and crime caper Now You See Me 2 was at three, taking $23m (\u00a316.2m).\nTeenage Mutant Ninja Turtles dropped to four with $14.8m (\u00a310.4m).\nFollowing a spate of poor performing sequels such as The Huntsman: Winter's War, Alice Through the Looking Glass and Ride Along 2, The Conjuring 2 opened nearly on par with its 2013 original.\n\"There's seemingly been a spell cast over the second instalments and The Conjuring, I think, broke that spell,\" said Paul Dergarabedian, senior media analyst for Comscore.\n\"Just the overall quality won over the audience in a genre that's generally looked down upon from a critical perspective.''\nBig budget CGI extravaganza Warcraft, taken from the hit video game franchise, reportedly cost $160m (\u00a3112.8m) to make, so effectively bombed in the US financially as well as critically.\nHowever, it was a phenomenal success overseas, particularly in China where it made $156m (\u00a3110m) in its first five days, surpassing 2015's Avengers: Age of Ultron to set a new record for the biggest debut for a foreign release.\nThe game is particularly popular there, even spawning a theme park.\nThe magician crime caper Now You See Me 2, starring Jesse Eisenberg, Mark Ruffalo and Woody Harrelson, followed the disappointing trajectory of most recent sequels, dropping from its 2013 original opening debut of $29.4m (\u00a320.8) to $23m (\u00a316.2m).\nThe fifth Teenage Mutant Ninja Turtles movie, Out of the Shadows, fell to number four in only its second weekend.\nThe last movie in the franchise grossed nearly double in its opening weekend box office.\nRounding off the top five was X-Men: Apocalypse, taking $10m (\u00a37m) in a troubling third weekend.\nNext week sees the release of Pixar's Finding Nemo sequel, Finding Dory.",
+    "reference": "The Conjuring 2 has topped the North American box office chart in its first week of release, breaking a recent slump in success for movie sequels.",
+    "prediction": "The Conjuring 2 has topped the US and Canada box office for the third time in four years.",
+    "entities": [
+      {
+        "ent": "four years",
+        "type": "DATE",
+        "start": 78,
+        "end": 88,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0002031923650065437,
+        "posterior_prob": 0.19729569554328918
+      }
+    ]
+  },
+  {
+    "source": "The horror starring Vera Farmiga and Patrick Wilson as paranormal investigators made $40.4m (\u00a328.5m).\nVideo game adaptation Warcraft came in second with $24.4m (\u00a317.2m) and crime caper Now You See Me 2 was at three, taking $23m (\u00a316.2m).\nTeenage Mutant Ninja Turtles dropped to four with $14.8m (\u00a310.4m).\nFollowing a spate of poor performing sequels such as The Huntsman: Winter's War, Alice Through the Looking Glass and Ride Along 2, The Conjuring 2 opened nearly on par with its 2013 original.\n\"There's seemingly been a spell cast over the second instalments and The Conjuring, I think, broke that spell,\" said Paul Dergarabedian, senior media analyst for Comscore.\n\"Just the overall quality won over the audience in a genre that's generally looked down upon from a critical perspective.''\nBig budget CGI extravaganza Warcraft, taken from the hit video game franchise, reportedly cost $160m (\u00a3112.8m) to make, so effectively bombed in the US financially as well as critically.\nHowever, it was a phenomenal success overseas, particularly in China where it made $156m (\u00a3110m) in its first five days, surpassing 2015's Avengers: Age of Ultron to set a new record for the biggest debut for a foreign release.\nThe game is particularly popular there, even spawning a theme park.\nThe magician crime caper Now You See Me 2, starring Jesse Eisenberg, Mark Ruffalo and Woody Harrelson, followed the disappointing trajectory of most recent sequels, dropping from its 2013 original opening debut of $29.4m (\u00a320.8) to $23m (\u00a316.2m).\nThe fifth Teenage Mutant Ninja Turtles movie, Out of the Shadows, fell to number four in only its second weekend.\nThe last movie in the franchise grossed nearly double in its opening weekend box office.\nRounding off the top five was X-Men: Apocalypse, taking $10m (\u00a37m) in a troubling third weekend.\nNext week sees the release of Pixar's Finding Nemo sequel, Finding Dory.",
+    "reference": "The Conjuring 2 has topped the North American box office chart in its first week of release, breaking a recent slump in success for movie sequels.",
+    "prediction": "The Conjuring 2 has topped the US and US box office for a second weekend, ending a run of disappointing sequels.",
+    "entities": [
+      {
+        "ent": "a second weekend",
+        "type": "DATE",
+        "start": 56,
+        "end": 72,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 2.353938361920882e-05,
+        "posterior_prob": 0.08755314350128174
+      }
+    ]
+  },
+  {
+    "source": "It is a talent that helped him move from being bankrupt, aged 32, to becoming a multimillionaire by the time he was 48.\nAlong the way he created and sold best-selling upmarket crisps brand Tyrrells, and won a high-profile battle against supermarket giant Tesco.\nNow 56, and the founder and owner of Chase Vodka, a luxury version of the spirit made from potatoes grown on his farm, the serial entrepreneur says: \"People love stories, the real stories behind things.\n\"And the media was very important to me from the first days of Tyrrells.\n\"I was a guy who had been beaten up by the supermarkets, and people love to support the underdog.\"\nThe son of potato farmers who lived near the Herefordshire town of Leominster, Mr Chase bought the family farm from his dad when he was 20 after he \"managed to find a bank manager brave enough to lend me \u00a3200,000\".\nAs the cost of potatoes can rise and fall sharply, business was up and down for the next 12 years, until torrential rain in 1992 meant he couldn't harvest his crop, which he had to leave to rot in the fields.\nOverextended financially, the business collapsed, and Mr Chase had to file for bankruptcy. He says: \"I was very ashamed and embarrassed.\"\nAfter \"running away to Australia\" for a few months, he returned to Herefordshire, and was able to borrow funds to buy back the farm from the receivers, and start up in business again.\nThis time, to make extra money, he became a potato trader, buying spuds from a number of farms, and then selling them on to supermarkets.\nYet while he got himself back on his feet financially, Mr Chase says he became increasingly frustrated that supermarkets would reject potatoes that weren't \"cosmetically perfect\".\nHe adds: \"I'd send off 10 loads of spuds every day, and I'd be getting five back. It was very painful how the supermarkets were treating us farmers.\"\nMr Chase's life-changing moment came in 2002 when he found out that rejected potatoes were being bought up by the UK operation of US crisp-maker Kettle.\nAt the time Kettle was one of new companies making so-called \"posh crisps\", potato crisps which were cut a little thicker than the mass-market brands, and fried by hand.\nDespite having no crisp-making experience or knowledge, Mr Chase was convinced he could set up his own upmarket crisps brand.\nSo he phoned a few UK crisp-makers to ask if he could see how they did things, and all said \"no\". Undeterred, he flew out to the US and visited facilities in Pennsylvania and Colorado.\nReturning to the UK, he built a crisp-making facility at the family farm, and Tyrrells [taking its name from the property] was up and running six months later.\nQuick to tell his story to local newspapers to build up publicity, Mr Chase hit the road to spend two weeks visiting independent food shops across the UK with samples of his crisps.\nHe says: \"Tyrrells grew and grew very quickly, and it was a brilliant cash cow. We'd sell the bags to shops for \u00a31 and they would retail them for \u00a32. For us the net profit was 35%.\"\nSupermarkets such as Waitrose soon followed suit, but Mr Chase was adamant that he would not sell to the largest - Tesco - because he didn't like what he saw as the pressure it put on farmers to lower their prices.\nThen one day in 2006 a friend told him that Tesco was selling Tyrrells' crisps. It transpired that Tesco had been buying them on the grey market, and selling them below the recommended retail price.\nAn incensed Mr Chase demanded that Tesco stop selling them. After the supermarket refused, Mr Chase started a media campaign that included an appearance on BBC Radio 4's Today programme. Tesco then did back down.\nWith sales of Tyrrells crisps continuing to grow over the next few years, and annual turnover hitting \u00a314m, Mr Chase borrowed money from his bank to expand production. The condition the bank set was that he had to bring in a management team to help him run the business.\nMr Chase, who had previously been very hands on, and liked to help out with all parts of the business, says that bringing in new managers ultimately changed the business - to its detriment.\n\"We got to a stage where I didn't like where the business was going,\" he says. \"We were employing corporate people who were arranging meetings about more meetings.\"\nUnhappy with Tyrrells' new big business ethos, and going through a \"messy divorce\", Mr Chase - who was the sole shareholder - decided to sell up in 2008 to a private capital business for almost \u00a340m.\nLooking for a new business venture, and with the new owners of Tyrrells choosing to buy their potatoes from elsewhere, Mr Chase came up with the idea of turning his spuds into premium vodka.\nSo with money no longer a problem, he bought a distillation system, and Chase Vodka was born.\nAimed at the luxury end of the market, it retails for \u00a335 a bottle.\nWhile Mr Chase admits it isn't anywhere near as profitable as selling crisps, it appears to be very much a labour of love. And focused very much on exports, he spends a lot of time travelling the world to build up sales.\nAnd showing that he has lost little of his public relations skills, every year he flies influential barmen and women from around the world to visit his farm in Herefordshire to see how the potatoes are grown, and vodka is made.\nAlso now making a gin and a whisky, the Chase Distillery sells 10,000 bottles a week.\nMr Chase says: \"You have to tell people your story if you want to build your brand. But there has to be real DNA behind it if you want to be successful.\"",
+    "reference": "For a Herefordshire potato farmer, William Chase is impressively savvy about the need for positive publicity, and the importance of telling a good story.",
+    "prediction": "For a man who grew up on a potato farm in Herefordshire, Peter Chase has a natural knack for telling stories.",
+    "entities": [
+      {
+        "ent": "Peter",
+        "type": "PERSON",
+        "start": 57,
+        "end": 62,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.0006642508087679744,
+        "posterior_prob": 0.05579814314842224
+      }
+    ]
+  },
+  {
+    "source": "It is a talent that helped him move from being bankrupt, aged 32, to becoming a multimillionaire by the time he was 48.\nAlong the way he created and sold best-selling upmarket crisps brand Tyrrells, and won a high-profile battle against supermarket giant Tesco.\nNow 56, and the founder and owner of Chase Vodka, a luxury version of the spirit made from potatoes grown on his farm, the serial entrepreneur says: \"People love stories, the real stories behind things.\n\"And the media was very important to me from the first days of Tyrrells.\n\"I was a guy who had been beaten up by the supermarkets, and people love to support the underdog.\"\nThe son of potato farmers who lived near the Herefordshire town of Leominster, Mr Chase bought the family farm from his dad when he was 20 after he \"managed to find a bank manager brave enough to lend me \u00a3200,000\".\nAs the cost of potatoes can rise and fall sharply, business was up and down for the next 12 years, until torrential rain in 1992 meant he couldn't harvest his crop, which he had to leave to rot in the fields.\nOverextended financially, the business collapsed, and Mr Chase had to file for bankruptcy. He says: \"I was very ashamed and embarrassed.\"\nAfter \"running away to Australia\" for a few months, he returned to Herefordshire, and was able to borrow funds to buy back the farm from the receivers, and start up in business again.\nThis time, to make extra money, he became a potato trader, buying spuds from a number of farms, and then selling them on to supermarkets.\nYet while he got himself back on his feet financially, Mr Chase says he became increasingly frustrated that supermarkets would reject potatoes that weren't \"cosmetically perfect\".\nHe adds: \"I'd send off 10 loads of spuds every day, and I'd be getting five back. It was very painful how the supermarkets were treating us farmers.\"\nMr Chase's life-changing moment came in 2002 when he found out that rejected potatoes were being bought up by the UK operation of US crisp-maker Kettle.\nAt the time Kettle was one of new companies making so-called \"posh crisps\", potato crisps which were cut a little thicker than the mass-market brands, and fried by hand.\nDespite having no crisp-making experience or knowledge, Mr Chase was convinced he could set up his own upmarket crisps brand.\nSo he phoned a few UK crisp-makers to ask if he could see how they did things, and all said \"no\". Undeterred, he flew out to the US and visited facilities in Pennsylvania and Colorado.\nReturning to the UK, he built a crisp-making facility at the family farm, and Tyrrells [taking its name from the property] was up and running six months later.\nQuick to tell his story to local newspapers to build up publicity, Mr Chase hit the road to spend two weeks visiting independent food shops across the UK with samples of his crisps.\nHe says: \"Tyrrells grew and grew very quickly, and it was a brilliant cash cow. We'd sell the bags to shops for \u00a31 and they would retail them for \u00a32. For us the net profit was 35%.\"\nSupermarkets such as Waitrose soon followed suit, but Mr Chase was adamant that he would not sell to the largest - Tesco - because he didn't like what he saw as the pressure it put on farmers to lower their prices.\nThen one day in 2006 a friend told him that Tesco was selling Tyrrells' crisps. It transpired that Tesco had been buying them on the grey market, and selling them below the recommended retail price.\nAn incensed Mr Chase demanded that Tesco stop selling them. After the supermarket refused, Mr Chase started a media campaign that included an appearance on BBC Radio 4's Today programme. Tesco then did back down.\nWith sales of Tyrrells crisps continuing to grow over the next few years, and annual turnover hitting \u00a314m, Mr Chase borrowed money from his bank to expand production. The condition the bank set was that he had to bring in a management team to help him run the business.\nMr Chase, who had previously been very hands on, and liked to help out with all parts of the business, says that bringing in new managers ultimately changed the business - to its detriment.\n\"We got to a stage where I didn't like where the business was going,\" he says. \"We were employing corporate people who were arranging meetings about more meetings.\"\nUnhappy with Tyrrells' new big business ethos, and going through a \"messy divorce\", Mr Chase - who was the sole shareholder - decided to sell up in 2008 to a private capital business for almost \u00a340m.\nLooking for a new business venture, and with the new owners of Tyrrells choosing to buy their potatoes from elsewhere, Mr Chase came up with the idea of turning his spuds into premium vodka.\nSo with money no longer a problem, he bought a distillation system, and Chase Vodka was born.\nAimed at the luxury end of the market, it retails for \u00a335 a bottle.\nWhile Mr Chase admits it isn't anywhere near as profitable as selling crisps, it appears to be very much a labour of love. And focused very much on exports, he spends a lot of time travelling the world to build up sales.\nAnd showing that he has lost little of his public relations skills, every year he flies influential barmen and women from around the world to visit his farm in Herefordshire to see how the potatoes are grown, and vodka is made.\nAlso now making a gin and a whisky, the Chase Distillery sells 10,000 bottles a week.\nMr Chase says: \"You have to tell people your story if you want to build your brand. But there has to be real DNA behind it if you want to be successful.\"",
+    "reference": "For a Herefordshire potato farmer, William Chase is impressively savvy about the need for positive publicity, and the importance of telling a good story.",
+    "prediction": "For a man who grew up on a potato farm in Herefordshire, Steve Chase has a lot of talent.",
+    "entities": [
+      {
+        "ent": "Steve",
+        "type": "PERSON",
+        "start": 57,
+        "end": 62,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.001010967418551445,
+        "posterior_prob": 0.01060645654797554
+      }
+    ]
+  },
+  {
+    "source": "The proposal concerns routes that make up the Belfast Rapid Transit (BRT) plan.\nCurrently bus lanes in Belfast run from 07:30 until 09:30 and from 15:30 until 18:30. Under the proposals this would be extended from 07:00 to 19:00.\nThe project is due to come into operation in September 2018.\n\"We should remember in 2012 the business case for the Belfast Rapid Transit was built upon the concept that these would be 12-hour, seven-to-seven bus lane priorities,\" said Mr Hazzard.\n\"That is so we can have maximum compliance and avoid confusion.\"\nWest Belfast\nEast Belfast\nTitanic Quarter\nMr Hazzard said there would be two rounds of consultation on the proposals and said there could be some room for flexibility.\n\"What we can do and looking at other cities - Dublin for example - we may have loading and unloading windows and drop-off and pick-up times, where you have windows into that,\" he said.\n\"This is through consultation with those commuters, with those stakeholders and the community along the route so we can design our proposals and then go to a formal consultation period after.\"\nHe added: \"These buses and vehicles will be coming across every seven minutes in and out of the city, it's so, so important that we get this right.\"",
+    "reference": "Transport Minister Chris Hazzard is proposing to extend the times of bus lanes on some of Belfast's busiest commuting routes.",
+    "prediction": "Belfast's transport minister, David Hazzard, has announced plans to extend the opening hours of bus lanes in the city.",
+    "entities": [
+      {
+        "ent": "David",
+        "type": "PERSON",
+        "start": 30,
+        "end": 35,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.020088138058781624,
+        "posterior_prob": 0.1641373336315155
+      },
+      {
+        "ent": "the opening hours",
+        "type": "TIME",
+        "start": 75,
+        "end": 92,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.00030021919519640505,
+        "posterior_prob": 0.5768910646438599
+      }
+    ]
+  },
+  {
+    "source": "The proposal concerns routes that make up the Belfast Rapid Transit (BRT) plan.\nCurrently bus lanes in Belfast run from 07:30 until 09:30 and from 15:30 until 18:30. Under the proposals this would be extended from 07:00 to 19:00.\nThe project is due to come into operation in September 2018.\n\"We should remember in 2012 the business case for the Belfast Rapid Transit was built upon the concept that these would be 12-hour, seven-to-seven bus lane priorities,\" said Mr Hazzard.\n\"That is so we can have maximum compliance and avoid confusion.\"\nWest Belfast\nEast Belfast\nTitanic Quarter\nMr Hazzard said there would be two rounds of consultation on the proposals and said there could be some room for flexibility.\n\"What we can do and looking at other cities - Dublin for example - we may have loading and unloading windows and drop-off and pick-up times, where you have windows into that,\" he said.\n\"This is through consultation with those commuters, with those stakeholders and the community along the route so we can design our proposals and then go to a formal consultation period after.\"\nHe added: \"These buses and vehicles will be coming across every seven minutes in and out of the city, it's so, so important that we get this right.\"",
+    "reference": "Transport Minister Chris Hazzard is proposing to extend the times of bus lanes on some of Belfast's busiest commuting routes.",
+    "prediction": "Belfast's transport minister, Jim Hazzard, has announced plans to extend the hours of bus lanes in the city.",
+    "entities": [
+      {
+        "ent": "the hours",
+        "type": "TIME",
+        "start": 73,
+        "end": 82,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.0028490303084254265,
+        "posterior_prob": 0.010987908579409122
+      }
+    ]
+  },
+  {
+    "source": "The proposal concerns routes that make up the Belfast Rapid Transit (BRT) plan.\nCurrently bus lanes in Belfast run from 07:30 until 09:30 and from 15:30 until 18:30. Under the proposals this would be extended from 07:00 to 19:00.\nThe project is due to come into operation in September 2018.\n\"We should remember in 2012 the business case for the Belfast Rapid Transit was built upon the concept that these would be 12-hour, seven-to-seven bus lane priorities,\" said Mr Hazzard.\n\"That is so we can have maximum compliance and avoid confusion.\"\nWest Belfast\nEast Belfast\nTitanic Quarter\nMr Hazzard said there would be two rounds of consultation on the proposals and said there could be some room for flexibility.\n\"What we can do and looking at other cities - Dublin for example - we may have loading and unloading windows and drop-off and pick-up times, where you have windows into that,\" he said.\n\"This is through consultation with those commuters, with those stakeholders and the community along the route so we can design our proposals and then go to a formal consultation period after.\"\nHe added: \"These buses and vehicles will be coming across every seven minutes in and out of the city, it's so, so important that we get this right.\"",
+    "reference": "Transport Minister Chris Hazzard is proposing to extend the times of bus lanes on some of Belfast's busiest commuting routes.",
+    "prediction": "Plans to extend bus lanes in Belfast city centre from 07:30 to 19:00 have been unveiled by Transport Minister Chris Hazzard.",
+    "entities": [
+      {
+        "ent": "07:30 to 19:00",
+        "type": "TIME",
+        "start": 54,
+        "end": 68,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 3.181116170480891e-08,
+        "posterior_prob": 0.026373596861958504
+      },
+      {
+        "ent": "Chris",
+        "type": "PERSON",
+        "start": 110,
+        "end": 115,
+        "in_source": false,
+        "label": "Factual Hallucination",
+        "prior_prob": 0.01757625676691532,
+        "posterior_prob": 0.037576526403427124
+      }
+    ]
+  },
+  {
+    "source": "The proposal concerns routes that make up the Belfast Rapid Transit (BRT) plan.\nCurrently bus lanes in Belfast run from 07:30 until 09:30 and from 15:30 until 18:30. Under the proposals this would be extended from 07:00 to 19:00.\nThe project is due to come into operation in September 2018.\n\"We should remember in 2012 the business case for the Belfast Rapid Transit was built upon the concept that these would be 12-hour, seven-to-seven bus lane priorities,\" said Mr Hazzard.\n\"That is so we can have maximum compliance and avoid confusion.\"\nWest Belfast\nEast Belfast\nTitanic Quarter\nMr Hazzard said there would be two rounds of consultation on the proposals and said there could be some room for flexibility.\n\"What we can do and looking at other cities - Dublin for example - we may have loading and unloading windows and drop-off and pick-up times, where you have windows into that,\" he said.\n\"This is through consultation with those commuters, with those stakeholders and the community along the route so we can design our proposals and then go to a formal consultation period after.\"\nHe added: \"These buses and vehicles will be coming across every seven minutes in and out of the city, it's so, so important that we get this right.\"",
+    "reference": "Transport Minister Chris Hazzard is proposing to extend the times of bus lanes on some of Belfast's busiest commuting routes.",
+    "prediction": "Belfast's transport minister, Simon Hazzard, has announced plans to extend bus lanes in the city.",
+    "entities": [
+      {
+        "ent": "Simon",
+        "type": "PERSON",
+        "start": 30,
+        "end": 35,
+        "in_source": false,
+        "label": "Non-factual Hallucination",
+        "prior_prob": 0.007156500592827797,
+        "posterior_prob": 0.25209471583366394
+      }
+    ]
+  }
+]


### PR DESCRIPTION
interpretation:
- the kNN does much worse on identifying factual hallucinations than (factual) non-hallucinations
- comparing test set performance xent-test -> xent-extended, the kNN does a better job at picking out non-factual hallucinations and worse at picking out factual hallucinations.
  - perhaps xent-extended is just "harder" than xent-test

![Screen Shot 2022-05-16 at 4 25 16 PM](https://user-images.githubusercontent.com/1561546/168677562-71fa66a9-c3e3-47cc-8c37-9c631949de9d.png)
