### PR TITLE
Made evaluation fully strict by default [Blocked]

### DIFF
--- a/evaluate_summaries.py
+++ b/evaluate_summaries.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--annotate", type=bool, default=False)
     parser.add_argument("--test_size", type=int, default=100)
-    parser.add_argument("--entity_label_match", type=str, default="strict_intrinsic")
+    parser.add_argument("--entity_label_match", type=str, default="strict_all")
     parser.add_argument("--print_first_n", type=int, default=0)
     parser.add_argument("--model_filter", type=str, default="")
     parser.add_argument("--count_skips", type=bool, default=False)


### PR DESCRIPTION
This change ensures that extrinsic annotations are also strictly matched. Ie we don't assume an extrinsic entity to be factual in any if it was previously annotated. 

This increases the annotation need for the 100 set like so:
```
Model: fbs_oracle
Would you like to annotate 20 unknown entities? (y/n)
Model: fbs_classifier
Would you like to annotate 15 unknown entities? (y/n)
Model: baseline
Would you like to annotate 9 unknown entities? (y/n)
Model: corrector
Would you like to annotate 17 unknown entities? (y/n)
```

Waiting to annotate these until other pieces fall into place.

Blocked by:
- [x] #41 Updated annotations
- [x] Decision on which test set to use