### PR TITLE
Added support for running FBS on top of Pegasus

### DIFF
--- a/results/debug-oracle.json
+++ b/results/debug-oracle.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1654616847.099363,
+  "timestamp": 1654621130.145793,
   "args": {
     "pickled_classifier": "",
     "classifier_batch_size": 4,
@@ -153,7 +153,7 @@
           "generation_metadata": {
             "score": -0.48298680782318115,
             "dropped_seqs": [],
-            "n_words_checked": 77
+            "n_words_checked": 65
           },
           "labeled_entities": [
             {
@@ -223,7 +223,7 @@
           "generation_metadata": {
             "score": -0.5601837038993835,
             "dropped_seqs": [],
-            "n_words_checked": 89
+            "n_words_checked": 81
           },
           "labeled_entities": [
             {
@@ -293,7 +293,7 @@
           "generation_metadata": {
             "score": -0.45060160756111145,
             "dropped_seqs": [],
-            "n_words_checked": 81
+            "n_words_checked": 73
           },
           "labeled_entities": [
             {
@@ -344,7 +344,7 @@
           "generation_metadata": {
             "score": -0.8142673969268799,
             "dropped_seqs": [],
-            "n_words_checked": 96
+            "n_words_checked": 84
           },
           "labeled_entities": [
             {
@@ -459,8 +459,8 @@
       "summaries": {
         "37066389": {
           "banned_phrases": [
-            "Omar",
-            "Kazakhstan"
+            "Kazakhstan",
+            "Omar"
           ],
           "summary": "Colombia's Carlos Martinez has been beaten in the Olympic men's flyweight final by Uzbekistan's Islam Dusmatov.",
           "generation_metadata": {
@@ -592,7 +592,7 @@
             "dropped_seqs": [
               "</s>Liam Payne and Niall"
             ],
-            "n_words_checked": 81
+            "n_words_checked": 65
           },
           "labeled_entities": [
             {
@@ -631,8 +631,8 @@
         },
         "34361828": {
           "banned_phrases": [
-            "the 1970s",
-            "Pembrokeshire"
+            "Pembrokeshire",
+            "the 1970s"
           ],
           "summary": "A search is under way for the remains of a Gwynedd village which was wiped out by storms in the 1950s.",
           "generation_metadata": {
@@ -674,7 +674,7 @@
               "</s>Plans to cut home-to-school transport subsidies in Gloucestershire",
               "</s>Plans to cut home-to-school transport subsidies for children in Gloucestershire"
             ],
-            "n_words_checked": 81
+            "n_words_checked": 69
           },
           "labeled_entities": [
             {
@@ -746,26 +746,55 @@
         },
         "36396523": {
           "banned_phrases": [
-            "next month's",
             "World Cup",
+            "next month's",
             "South America"
           ],
-          "summary": "<Failed generation: blocked all beams>",
+          "summary": "Kaka has been called up to the Brazil squad for the Copa America next month.",
           "generation_metadata": {
             "score": -0.5828989744186401,
             "dropped_seqs": [
               "</s>Brazil have added Kaka to their squad for next month's",
               "</s>Brazil have added Kaka to their squad for the Under-20 World Cup",
               "</s>Brazil have called up Kaka to their squad for the Under-20 World Cup",
-              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup",
-              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>",
-              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>",
-              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>",
-              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>"
+              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup"
             ],
-            "n_words_checked": 84
+            "n_words_checked": 64
           },
-          "labeled_entities": []
+          "labeled_entities": [
+            {
+              "ent": "Kaka",
+              "type": "PERSON",
+              "start": 0,
+              "end": 4,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Brazil",
+              "type": "GPE",
+              "start": 31,
+              "end": 37,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "the Copa America",
+              "type": "ORG",
+              "start": 48,
+              "end": 64,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            },
+            {
+              "ent": "next month",
+              "type": "DATE",
+              "start": 65,
+              "end": 75,
+              "in_source": false,
+              "label": "Non-factual Hallucination"
+            }
+          ]
         },
         "36203675": {
           "banned_phrases": [
@@ -794,36 +823,36 @@
       },
       "stats": {
         "summary": {
-          "completed": 3,
+          "completed": 2,
           "total": 10,
           "factual": 2,
-          "non_factual": 7,
-          "failed": 1,
+          "non_factual": 8,
+          "failed": 0,
           "unknown": 0
         },
         "entity": {
           "label": {
-            "Non-factual Hallucination": 9,
-            "Factual Hallucination": 2,
+            "Non-factual Hallucination": 10,
+            "Factual Hallucination": 3,
             "Unknown": 0,
-            "Non-hallucinated": 12,
+            "Non-hallucinated": 14,
             "Intrinsic Hallucination": 0
           },
           "type": {
             "PERSON": {
-              "total": 11,
+              "total": 12,
               "Non-factual Hallucination": 4,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 7,
+              "Non-hallucinated": 8,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 7,
+              "total": 8,
               "Non-factual Hallucination": 2,
               "Factual Hallucination": 2,
               "Unknown": 0,
-              "Non-hallucinated": 3,
+              "Non-hallucinated": 4,
               "Intrinsic Hallucination": 0
             },
             "FAC": {
@@ -843,17 +872,17 @@
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 2,
-              "Non-factual Hallucination": 1,
+              "total": 3,
+              "Non-factual Hallucination": 2,
               "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
             },
             "ORG": {
-              "total": 1,
+              "total": 2,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 0,
+              "Factual Hallucination": 1,
               "Unknown": 0,
               "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
@@ -866,9 +895,9 @@
       "summaries": {
         "37066389": {
           "banned_phrases": [
-            "Omar",
+            "Carlos",
             "Kazakhstan",
-            "Carlos"
+            "Omar"
           ],
           "summary": "Colombia's Gabriel Martinez has been beaten in the Olympic men's flyweight final by Uzbekistan's Islam Dusmatov.",
           "generation_metadata": {
@@ -922,8 +951,8 @@
         },
         "24403775": {
           "banned_phrases": [
-            "Shropshire",
-            "Shrewsbury"
+            "Shrewsbury",
+            "Shropshire"
           ],
           "summary": "A campaign has been launched to get Stonehenge Bottom's main road re-opened after it was closed to traffic.",
           "generation_metadata": {
@@ -932,7 +961,7 @@
               "</s>Villagers in Shropshire",
               "</s>Villagers in Shrewsbury"
             ],
-            "n_words_checked": 91
+            "n_words_checked": 79
           },
           "labeled_entities": [
             {
@@ -947,8 +976,8 @@
         },
         "37615223": {
           "banned_phrases": [
-            "third",
-            "the Amex Stadium"
+            "the Amex Stadium",
+            "third"
           ],
           "summary": "Sam Baldock scored the only goal of the game as Brighton beat Wolves to move up to fourth in the Championship.",
           "generation_metadata": {
@@ -989,10 +1018,10 @@
         },
         "32112735": {
           "banned_phrases": [
-            "Horan",
+            "Louis",
             "Tomlinson",
-            "Niall",
-            "Louis"
+            "Horan",
+            "Niall"
           ],
           "summary": "One Direction have confirmed they're staying in the band.",
           "generation_metadata": {
@@ -1002,7 +1031,7 @@
               "</s>Liam Payne, Louis",
               "</s>Liam Payne and Niall"
             ],
-            "n_words_checked": 78
+            "n_words_checked": 42
           },
           "labeled_entities": [
             {
@@ -1017,10 +1046,10 @@
         },
         "34361828": {
           "banned_phrases": [
-            "Gwynedd village",
+            "Pembrokeshire",
             "the 1970s",
             "the 1950s",
-            "Pembrokeshire"
+            "Gwynedd village"
           ],
           "summary": "A search is under way to find the remains of a Gower village which was destroyed by the sea in the 1950's.",
           "generation_metadata": {
@@ -1067,7 +1096,7 @@
               "</s>Plans to cut home-to-school transport subsidies for children in Flintshire",
               "</s>Plans to cut home-to-school transport subsidies for children in Gloucestershire"
             ],
-            "n_words_checked": 85
+            "n_words_checked": 73
           },
           "labeled_entities": [
             {
@@ -1080,6 +1109,69 @@
             }
           ]
         },
+        "36396523": {
+          "banned_phrases": [
+            "next month",
+            "World Cup",
+            "next month's",
+            "South America"
+          ],
+          "summary": "Kaka has been called up to the Brazil squad for the Copa America in Chile in June.",
+          "generation_metadata": {
+            "score": -0.6230838298797607,
+            "dropped_seqs": [
+              "</s>Brazil have added Kaka to their squad for next month",
+              "</s>Brazil have added Kaka to their squad for the Under-20 World Cup",
+              "</s>Brazil have called up Kaka to their squad for the Under-20 World Cup",
+              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup",
+              "</s>Kaka has been called up to the Brazil squad for the Copa America next month",
+              "</s>Kaka has been called up to the Brazil squad for the Copa America in Chile next month"
+            ],
+            "n_words_checked": 93
+          },
+          "labeled_entities": [
+            {
+              "ent": "Kaka",
+              "type": "PERSON",
+              "start": 0,
+              "end": 4,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Brazil",
+              "type": "GPE",
+              "start": 31,
+              "end": 37,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "the Copa America",
+              "type": "ORG",
+              "start": 48,
+              "end": 64,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            },
+            {
+              "ent": "Chile",
+              "type": "GPE",
+              "start": 68,
+              "end": 73,
+              "in_source": false,
+              "label": "Non-factual Hallucination"
+            },
+            {
+              "ent": "June",
+              "type": "DATE",
+              "start": 77,
+              "end": 81,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            }
+          ]
+        },
         "36203675": {
           "banned_phrases": [
             "the University of Bristol",
@@ -1087,7 +1179,7 @@
           ],
           "summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Cambridge.",
           "generation_metadata": {
-            "score": -0.8350397348403931,
+            "score": -0.8350398540496826,
             "dropped_seqs": [
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Bristol",
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Oxford",
@@ -1110,36 +1202,36 @@
       },
       "stats": {
         "summary": {
-          "completed": 5,
+          "completed": 4,
           "total": 10,
           "factual": 4,
-          "non_factual": 5,
-          "failed": 1,
+          "non_factual": 6,
+          "failed": 0,
           "unknown": 0
         },
         "entity": {
           "label": {
-            "Non-factual Hallucination": 5,
-            "Factual Hallucination": 2,
+            "Non-factual Hallucination": 6,
+            "Factual Hallucination": 4,
             "Unknown": 0,
-            "Non-hallucinated": 12,
+            "Non-hallucinated": 14,
             "Intrinsic Hallucination": 0
           },
           "type": {
             "PERSON": {
-              "total": 6,
+              "total": 7,
               "Non-factual Hallucination": 1,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 5,
+              "Non-hallucinated": 6,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 7,
-              "Non-factual Hallucination": 1,
+              "total": 9,
+              "Non-factual Hallucination": 2,
               "Factual Hallucination": 2,
               "Unknown": 0,
-              "Non-hallucinated": 4,
+              "Non-hallucinated": 5,
               "Intrinsic Hallucination": 0
             },
             "FAC": {
@@ -1167,17 +1259,17 @@
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 2,
+              "total": 3,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 0,
+              "Factual Hallucination": 1,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
             },
             "ORG": {
-              "total": 1,
+              "total": 2,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 0,
+              "Factual Hallucination": 1,
               "Unknown": 0,
               "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
@@ -1190,10 +1282,10 @@
       "summaries": {
         "37066389": {
           "banned_phrases": [
-            "Omar",
-            "Kazakhstan",
+            "Gabriel",
             "Carlos",
-            "Gabriel"
+            "Kazakhstan",
+            "Omar"
           ],
           "summary": "Colombia's Jose Luis Martinez has been beaten in the Olympic men's flyweight final by Uzbekistan's Islam Dusmatov.",
           "generation_metadata": {
@@ -1258,8 +1350,8 @@
         },
         "37615223": {
           "banned_phrases": [
-            "third",
             "the Amex Stadium",
+            "third",
             "fourth"
           ],
           "summary": "Sam Baldock's first-half header was enough to give Brighton victory over Wolves at the Amex stadium.",
@@ -1322,10 +1414,10 @@
         "34361828": {
           "banned_phrases": [
             "the 1970s",
-            "Gwynedd village",
-            "the 1950s",
             "Pembrokeshire",
-            "1950"
+            "1950",
+            "the 1950s",
+            "Gwynedd village"
           ],
           "summary": "A search is under way to find the remains of a Gower village which was destroyed by the sea in the 1950's.",
           "generation_metadata": {
@@ -1361,8 +1453,8 @@
         },
         "17996567": {
           "banned_phrases": [
-            "Gloucestershire",
             "Staffordshire",
+            "Gloucestershire",
             "Flintshire"
           ],
           "summary": "Plans to cut home-to-school transport subsidies for children in Gloucesterse have been put on hold.",
@@ -1374,7 +1466,7 @@
               "</s>Plans to cut home-to-school transport subsidies for children in Staffordshire",
               "</s>Plans to cut home-to-school transport subsidies for children in Gloucestershire"
             ],
-            "n_words_checked": 84
+            "n_words_checked": 76
           },
           "labeled_entities": [
             {
@@ -1387,6 +1479,71 @@
             }
           ]
         },
+        "36396523": {
+          "banned_phrases": [
+            "World Cup",
+            "Chile",
+            "next month",
+            "South America",
+            "next month's"
+          ],
+          "summary": "Kaka has been called up to the Brazil squad for the Copa America in Brazil in June.",
+          "generation_metadata": {
+            "score": -0.6635534763336182,
+            "dropped_seqs": [
+              "</s>Brazil have added Kaka to their squad for next month",
+              "</s>Brazil have added Kaka to their squad for the Under-20 World Cup",
+              "</s>Brazil have called up Kaka to their squad for the Under-20 World Cup",
+              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup",
+              "</s>Kaka has been called up to the Brazil squad for the Copa America in Chile",
+              "</s>Kaka has been called up to the Brazil squad for the Copa America next month",
+              "</s>Kaka has been called up to the Brazil squad for the Copa America in Brazil next month"
+            ],
+            "n_words_checked": 93
+          },
+          "labeled_entities": [
+            {
+              "ent": "Kaka",
+              "type": "PERSON",
+              "start": 0,
+              "end": 4,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Brazil",
+              "type": "GPE",
+              "start": 31,
+              "end": 37,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "the Copa America",
+              "type": "ORG",
+              "start": 48,
+              "end": 64,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            },
+            {
+              "ent": "Brazil",
+              "type": "GPE",
+              "start": 68,
+              "end": 74,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "June",
+              "type": "DATE",
+              "start": 78,
+              "end": 82,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            }
+          ]
+        },
         "36203675": {
           "banned_phrases": [
             "the University of Bristol",
@@ -1395,7 +1552,7 @@
           ],
           "summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Manchester.",
           "generation_metadata": {
-            "score": -0.842137336730957,
+            "score": -0.8421373963356018,
             "dropped_seqs": [
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Bristol",
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Oxford",
@@ -1422,34 +1579,34 @@
         "summary": {
           "completed": 5,
           "total": 10,
-          "factual": 4,
+          "factual": 5,
           "non_factual": 5,
-          "failed": 1,
+          "failed": 0,
           "unknown": 0
         },
         "entity": {
           "label": {
             "Non-factual Hallucination": 6,
-            "Factual Hallucination": 3,
+            "Factual Hallucination": 5,
             "Unknown": 0,
-            "Non-hallucinated": 13,
+            "Non-hallucinated": 16,
             "Intrinsic Hallucination": 0
           },
           "type": {
             "PERSON": {
-              "total": 7,
+              "total": 8,
               "Non-factual Hallucination": 2,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 5,
+              "Non-hallucinated": 6,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 7,
+              "total": 9,
               "Non-factual Hallucination": 0,
               "Factual Hallucination": 2,
               "Unknown": 0,
-              "Non-hallucinated": 5,
+              "Non-hallucinated": 7,
               "Intrinsic Hallucination": 0
             },
             "FAC": {
@@ -1461,17 +1618,17 @@
               "Intrinsic Hallucination": 0
             },
             "ORG": {
-              "total": 3,
+              "total": 4,
               "Non-factual Hallucination": 3,
-              "Factual Hallucination": 0,
+              "Factual Hallucination": 1,
               "Unknown": 0,
               "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 3,
+              "total": 4,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 1,
+              "Factual Hallucination": 2,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
@@ -1492,12 +1649,12 @@
       "summaries": {
         "37066389": {
           "banned_phrases": [
-            "Omar",
-            "Carlos",
-            "Jose",
-            "Kazakhstan",
             "Luis",
-            "Gabriel"
+            "Jose",
+            "Carlos",
+            "Gabriel",
+            "Kazakhstan",
+            "Omar"
           ],
           "summary": "<Failed generation: blocked all beams>",
           "generation_metadata": {
@@ -1509,15 +1666,15 @@
               "</s>Colombia's Jose",
               "</s>Colombia's Gabriel"
             ],
-            "n_words_checked": 63
+            "n_words_checked": 27
           },
           "labeled_entities": []
         },
         "37615223": {
           "banned_phrases": [
-            "third",
             "the Amex Stadium",
             "Amex",
+            "third",
             "fourth"
           ],
           "summary": "Sam Baldock's first-half header was enough for Brighton to beat Wolves and move up to second in the Championship.",
@@ -1579,10 +1736,10 @@
         "34361828": {
           "banned_phrases": [
             "the 1970s",
-            "Gwynedd village",
-            "the 1950s",
             "Pembrokeshire",
-            "1950"
+            "1950",
+            "the 1950s",
+            "Gwynedd village"
           ],
           "summary": "A search is under way to find the remains of a Gower village which was destroyed by the sea in the 1950's.",
           "generation_metadata": {
@@ -1618,10 +1775,10 @@
         },
         "17996567": {
           "banned_phrases": [
+            "Staffordshire",
             "Gloucestershire",
-            "Gloucesterse",
             "Flintshire",
-            "Staffordshire"
+            "Gloucesterse"
           ],
           "summary": "Plans to cut home-to-school transport subsidies for children in Gloucestersfield have been put on hold.",
           "generation_metadata": {
@@ -1633,7 +1790,7 @@
               "</s>Plans to cut home-to-school transport subsidies for children in Gloucestershire",
               "</s>Plans to cut home-to-school transport subsidies for children in Gloucesterse"
             ],
-            "n_words_checked": 87
+            "n_words_checked": 79
           },
           "labeled_entities": [
             {
@@ -1649,9 +1806,9 @@
         "36203675": {
           "banned_phrases": [
             "the University of Bristol",
-            "the University of Manchester",
+            "the University of Oxford",
             "the University of Cambridge",
-            "the University of Oxford"
+            "the University of Manchester"
           ],
           "summary": "<Failed generation: blocked all beams>",
           "generation_metadata": {
@@ -1675,17 +1832,17 @@
         "summary": {
           "completed": 8,
           "total": 10,
-          "factual": 5,
+          "factual": 6,
           "non_factual": 2,
-          "failed": 3,
+          "failed": 2,
           "unknown": 0
         },
         "entity": {
           "label": {
             "Non-factual Hallucination": 2,
-            "Factual Hallucination": 2,
+            "Factual Hallucination": 4,
             "Unknown": 0,
-            "Non-hallucinated": 12,
+            "Non-hallucinated": 15,
             "Intrinsic Hallucination": 0
           },
           "type": {
@@ -1698,27 +1855,27 @@
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 3,
+              "total": 4,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 1,
+              "Factual Hallucination": 2,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
             },
             "PERSON": {
-              "total": 5,
+              "total": 6,
               "Non-factual Hallucination": 1,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 4,
+              "Non-hallucinated": 5,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 5,
+              "total": 7,
               "Non-factual Hallucination": 0,
               "Factual Hallucination": 1,
               "Unknown": 0,
-              "Non-hallucinated": 4,
+              "Non-hallucinated": 6,
               "Intrinsic Hallucination": 0
             },
             "ORDINAL": {
@@ -1735,6 +1892,14 @@
               "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 1,
+              "Intrinsic Hallucination": 0
+            },
+            "ORG": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 1,
+              "Unknown": 0,
+              "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
             }
           }

--- a/results/debug-oracle.json
+++ b/results/debug-oracle.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1654547675.8015912,
+  "timestamp": 1654616847.099363,
   "args": {
     "pickled_classifier": "",
     "classifier_batch_size": 4,
@@ -8,8 +8,8 @@
     "model_prior": "facebook/bart-large",
     "model_posterior": "entfa-cmlm",
     "max_iterations": 5,
-    "annotate": false,
-    "verbose": false,
+    "annotate": true,
+    "verbose": true,
     "batch_size": 2,
     "test_size": 100,
     "num_beams": 4,
@@ -747,54 +747,25 @@
         "36396523": {
           "banned_phrases": [
             "next month's",
-            "South America",
-            "World Cup"
+            "World Cup",
+            "South America"
           ],
-          "summary": "Kaka has been called up to the Brazil squad for the Copa America next month.",
+          "summary": "<Failed generation: blocked all beams>",
           "generation_metadata": {
             "score": -0.5828989744186401,
             "dropped_seqs": [
               "</s>Brazil have added Kaka to their squad for next month's",
               "</s>Brazil have added Kaka to their squad for the Under-20 World Cup",
               "</s>Brazil have called up Kaka to their squad for the Under-20 World Cup",
-              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup"
+              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup",
+              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>",
+              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>",
+              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>",
+              "</s>Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final World Cup<pad>"
             ],
             "n_words_checked": 84
           },
-          "labeled_entities": [
-            {
-              "ent": "Kaka",
-              "type": "PERSON",
-              "start": 0,
-              "end": 4,
-              "in_source": true,
-              "label": "Non-hallucinated"
-            },
-            {
-              "ent": "Brazil",
-              "type": "GPE",
-              "start": 31,
-              "end": 37,
-              "in_source": true,
-              "label": "Non-hallucinated"
-            },
-            {
-              "ent": "the Copa America",
-              "type": "ORG",
-              "start": 48,
-              "end": 64,
-              "in_source": false,
-              "label": "Factual Hallucination"
-            },
-            {
-              "ent": "next month",
-              "type": "DATE",
-              "start": 65,
-              "end": 75,
-              "in_source": false,
-              "label": "Non-factual Hallucination"
-            }
-          ]
+          "labeled_entities": []
         },
         "36203675": {
           "banned_phrases": [
@@ -823,36 +794,36 @@
       },
       "stats": {
         "summary": {
-          "completed": 2,
+          "completed": 3,
           "total": 10,
           "factual": 2,
-          "non_factual": 8,
-          "failed": 0,
+          "non_factual": 7,
+          "failed": 1,
           "unknown": 0
         },
         "entity": {
           "label": {
-            "Non-factual Hallucination": 10,
-            "Factual Hallucination": 3,
+            "Non-factual Hallucination": 9,
+            "Factual Hallucination": 2,
             "Unknown": 0,
-            "Non-hallucinated": 14,
+            "Non-hallucinated": 12,
             "Intrinsic Hallucination": 0
           },
           "type": {
             "PERSON": {
-              "total": 12,
+              "total": 11,
               "Non-factual Hallucination": 4,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 8,
+              "Non-hallucinated": 7,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 8,
+              "total": 7,
               "Non-factual Hallucination": 2,
               "Factual Hallucination": 2,
               "Unknown": 0,
-              "Non-hallucinated": 4,
+              "Non-hallucinated": 3,
               "Intrinsic Hallucination": 0
             },
             "FAC": {
@@ -872,17 +843,17 @@
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 3,
-              "Non-factual Hallucination": 2,
+              "total": 2,
+              "Non-factual Hallucination": 1,
               "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
             },
             "ORG": {
-              "total": 2,
+              "total": 1,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 1,
+              "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
@@ -951,8 +922,8 @@
         },
         "24403775": {
           "banned_phrases": [
-            "Shrewsbury",
-            "Shropshire"
+            "Shropshire",
+            "Shrewsbury"
           ],
           "summary": "A campaign has been launched to get Stonehenge Bottom's main road re-opened after it was closed to traffic.",
           "generation_metadata": {
@@ -976,8 +947,8 @@
         },
         "37615223": {
           "banned_phrases": [
-            "the Amex Stadium",
-            "third"
+            "third",
+            "the Amex Stadium"
           ],
           "summary": "Sam Baldock scored the only goal of the game as Brighton beat Wolves to move up to fourth in the Championship.",
           "generation_metadata": {
@@ -1019,9 +990,9 @@
         "32112735": {
           "banned_phrases": [
             "Horan",
-            "Louis",
+            "Tomlinson",
             "Niall",
-            "Tomlinson"
+            "Louis"
           ],
           "summary": "One Direction have confirmed they're staying in the band.",
           "generation_metadata": {
@@ -1085,8 +1056,8 @@
         },
         "17996567": {
           "banned_phrases": [
-            "Flintshire",
-            "Gloucestershire"
+            "Gloucestershire",
+            "Flintshire"
           ],
           "summary": "Plans to cut home-to-school transport subsidies for children in Staffordshire have been put on hold.",
           "generation_metadata": {
@@ -1109,69 +1080,6 @@
             }
           ]
         },
-        "36396523": {
-          "banned_phrases": [
-            "South America",
-            "next month's",
-            "next month",
-            "World Cup"
-          ],
-          "summary": "Kaka has been called up to the Brazil squad for the Copa America in Chile in June.",
-          "generation_metadata": {
-            "score": -0.6230838298797607,
-            "dropped_seqs": [
-              "</s>Brazil have added Kaka to their squad for next month",
-              "</s>Brazil have added Kaka to their squad for the Under-20 World Cup",
-              "</s>Brazil have called up Kaka to their squad for the Under-20 World Cup",
-              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup",
-              "</s>Kaka has been called up to the Brazil squad for the Copa America next month",
-              "</s>Kaka has been called up to the Brazil squad for the Copa America in Chile next month"
-            ],
-            "n_words_checked": 101
-          },
-          "labeled_entities": [
-            {
-              "ent": "Kaka",
-              "type": "PERSON",
-              "start": 0,
-              "end": 4,
-              "in_source": true,
-              "label": "Non-hallucinated"
-            },
-            {
-              "ent": "Brazil",
-              "type": "GPE",
-              "start": 31,
-              "end": 37,
-              "in_source": true,
-              "label": "Non-hallucinated"
-            },
-            {
-              "ent": "the Copa America",
-              "type": "ORG",
-              "start": 48,
-              "end": 64,
-              "in_source": false,
-              "label": "Factual Hallucination"
-            },
-            {
-              "ent": "Chile",
-              "type": "GPE",
-              "start": 68,
-              "end": 73,
-              "in_source": false,
-              "label": "Non-factual Hallucination"
-            },
-            {
-              "ent": "June",
-              "type": "DATE",
-              "start": 77,
-              "end": 81,
-              "in_source": false,
-              "label": "Factual Hallucination"
-            }
-          ]
-        },
         "36203675": {
           "banned_phrases": [
             "the University of Bristol",
@@ -1179,7 +1087,7 @@
           ],
           "summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Cambridge.",
           "generation_metadata": {
-            "score": -0.8350398540496826,
+            "score": -0.8350397348403931,
             "dropped_seqs": [
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Bristol",
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Oxford",
@@ -1202,36 +1110,36 @@
       },
       "stats": {
         "summary": {
-          "completed": 4,
+          "completed": 5,
           "total": 10,
           "factual": 4,
-          "non_factual": 6,
-          "failed": 0,
+          "non_factual": 5,
+          "failed": 1,
           "unknown": 0
         },
         "entity": {
           "label": {
-            "Non-factual Hallucination": 6,
-            "Factual Hallucination": 4,
+            "Non-factual Hallucination": 5,
+            "Factual Hallucination": 2,
             "Unknown": 0,
-            "Non-hallucinated": 14,
+            "Non-hallucinated": 12,
             "Intrinsic Hallucination": 0
           },
           "type": {
             "PERSON": {
-              "total": 7,
+              "total": 6,
               "Non-factual Hallucination": 1,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 6,
+              "Non-hallucinated": 5,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 9,
-              "Non-factual Hallucination": 2,
+              "total": 7,
+              "Non-factual Hallucination": 1,
               "Factual Hallucination": 2,
               "Unknown": 0,
-              "Non-hallucinated": 5,
+              "Non-hallucinated": 4,
               "Intrinsic Hallucination": 0
             },
             "FAC": {
@@ -1259,17 +1167,17 @@
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 3,
+              "total": 2,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 1,
+              "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
             },
             "ORG": {
-              "total": 2,
+              "total": 1,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 1,
+              "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
@@ -1284,8 +1192,8 @@
           "banned_phrases": [
             "Omar",
             "Kazakhstan",
-            "Gabriel",
-            "Carlos"
+            "Carlos",
+            "Gabriel"
           ],
           "summary": "Colombia's Jose Luis Martinez has been beaten in the Olympic men's flyweight final by Uzbekistan's Islam Dusmatov.",
           "generation_metadata": {
@@ -1350,9 +1258,9 @@
         },
         "37615223": {
           "banned_phrases": [
+            "third",
             "the Amex Stadium",
-            "fourth",
-            "third"
+            "fourth"
           ],
           "summary": "Sam Baldock's first-half header was enough to give Brighton victory over Wolves at the Amex stadium.",
           "generation_metadata": {
@@ -1413,11 +1321,11 @@
         },
         "34361828": {
           "banned_phrases": [
-            "1950",
+            "the 1970s",
             "Gwynedd village",
-            "Pembrokeshire",
             "the 1950s",
-            "the 1970s"
+            "Pembrokeshire",
+            "1950"
           ],
           "summary": "A search is under way to find the remains of a Gower village which was destroyed by the sea in the 1950's.",
           "generation_metadata": {
@@ -1453,9 +1361,9 @@
         },
         "17996567": {
           "banned_phrases": [
-            "Flintshire",
             "Gloucestershire",
-            "Staffordshire"
+            "Staffordshire",
+            "Flintshire"
           ],
           "summary": "Plans to cut home-to-school transport subsidies for children in Gloucesterse have been put on hold.",
           "generation_metadata": {
@@ -1479,71 +1387,6 @@
             }
           ]
         },
-        "36396523": {
-          "banned_phrases": [
-            "next month's",
-            "Chile",
-            "South America",
-            "next month",
-            "World Cup"
-          ],
-          "summary": "Kaka has been called up to the Brazil squad for the Copa America in Brazil in June.",
-          "generation_metadata": {
-            "score": -0.6635534763336182,
-            "dropped_seqs": [
-              "</s>Brazil have added Kaka to their squad for next month",
-              "</s>Brazil have added Kaka to their squad for the Under-20 World Cup",
-              "</s>Brazil have called up Kaka to their squad for the Under-20 World Cup",
-              "</s>Kaka has been called up to the Brazil squad for the Under-20 World Cup",
-              "</s>Kaka has been called up to the Brazil squad for the Copa America in Chile",
-              "</s>Kaka has been called up to the Brazil squad for the Copa America next month",
-              "</s>Kaka has been called up to the Brazil squad for the Copa America in Brazil next month"
-            ],
-            "n_words_checked": 93
-          },
-          "labeled_entities": [
-            {
-              "ent": "Kaka",
-              "type": "PERSON",
-              "start": 0,
-              "end": 4,
-              "in_source": true,
-              "label": "Non-hallucinated"
-            },
-            {
-              "ent": "Brazil",
-              "type": "GPE",
-              "start": 31,
-              "end": 37,
-              "in_source": true,
-              "label": "Non-hallucinated"
-            },
-            {
-              "ent": "the Copa America",
-              "type": "ORG",
-              "start": 48,
-              "end": 64,
-              "in_source": false,
-              "label": "Factual Hallucination"
-            },
-            {
-              "ent": "Brazil",
-              "type": "GPE",
-              "start": 68,
-              "end": 74,
-              "in_source": true,
-              "label": "Non-hallucinated"
-            },
-            {
-              "ent": "June",
-              "type": "DATE",
-              "start": 78,
-              "end": 82,
-              "in_source": false,
-              "label": "Factual Hallucination"
-            }
-          ]
-        },
         "36203675": {
           "banned_phrases": [
             "the University of Bristol",
@@ -1552,7 +1395,7 @@
           ],
           "summary": "A mobile game designed to help people with dementia is to be used by researchers at the University of Manchester.",
           "generation_metadata": {
-            "score": -0.8421373963356018,
+            "score": -0.842137336730957,
             "dropped_seqs": [
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Bristol",
               "</s>A mobile game designed to help people with dementia is being used by researchers at the University of Oxford",
@@ -1579,34 +1422,34 @@
         "summary": {
           "completed": 5,
           "total": 10,
-          "factual": 5,
+          "factual": 4,
           "non_factual": 5,
-          "failed": 0,
+          "failed": 1,
           "unknown": 0
         },
         "entity": {
           "label": {
             "Non-factual Hallucination": 6,
-            "Factual Hallucination": 5,
+            "Factual Hallucination": 3,
             "Unknown": 0,
-            "Non-hallucinated": 16,
+            "Non-hallucinated": 13,
             "Intrinsic Hallucination": 0
           },
           "type": {
             "PERSON": {
-              "total": 8,
+              "total": 7,
               "Non-factual Hallucination": 2,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 6,
+              "Non-hallucinated": 5,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 9,
+              "total": 7,
               "Non-factual Hallucination": 0,
               "Factual Hallucination": 2,
               "Unknown": 0,
-              "Non-hallucinated": 7,
+              "Non-hallucinated": 5,
               "Intrinsic Hallucination": 0
             },
             "FAC": {
@@ -1618,17 +1461,17 @@
               "Intrinsic Hallucination": 0
             },
             "ORG": {
-              "total": 4,
+              "total": 3,
               "Non-factual Hallucination": 3,
-              "Factual Hallucination": 1,
+              "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 4,
+              "total": 3,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 2,
+              "Factual Hallucination": 1,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
@@ -1649,12 +1492,12 @@
       "summaries": {
         "37066389": {
           "banned_phrases": [
-            "Gabriel",
-            "Kazakhstan",
             "Omar",
             "Carlos",
             "Jose",
-            "Luis"
+            "Kazakhstan",
+            "Luis",
+            "Gabriel"
           ],
           "summary": "<Failed generation: blocked all beams>",
           "generation_metadata": {
@@ -1672,10 +1515,10 @@
         },
         "37615223": {
           "banned_phrases": [
-            "Amex",
+            "third",
             "the Amex Stadium",
-            "fourth",
-            "third"
+            "Amex",
+            "fourth"
           ],
           "summary": "Sam Baldock's first-half header was enough for Brighton to beat Wolves and move up to second in the Championship.",
           "generation_metadata": {
@@ -1735,11 +1578,11 @@
         },
         "34361828": {
           "banned_phrases": [
-            "1950",
+            "the 1970s",
             "Gwynedd village",
-            "Pembrokeshire",
             "the 1950s",
-            "the 1970s"
+            "Pembrokeshire",
+            "1950"
           ],
           "summary": "A search is under way to find the remains of a Gower village which was destroyed by the sea in the 1950's.",
           "generation_metadata": {
@@ -1775,10 +1618,10 @@
         },
         "17996567": {
           "banned_phrases": [
-            "Flintshire",
             "Gloucestershire",
-            "Staffordshire",
-            "Gloucesterse"
+            "Gloucesterse",
+            "Flintshire",
+            "Staffordshire"
           ],
           "summary": "Plans to cut home-to-school transport subsidies for children in Gloucestersfield have been put on hold.",
           "generation_metadata": {
@@ -1820,7 +1663,8 @@
               "</s>A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol",
               "</s>A mobile game designed to help people with dementia is to be used by researchers at the University of Oxford",
               "</s>A mobile game designed to help people with dementia is to be used by researchers at the University of Cambridge",
-              "</s>A mobile game designed to help people with dementia is to be used by researchers at the University of Manchester"
+              "</s>A mobile game designed to help people with dementia is to be used by researchers at the University of Manchester",
+              "</s>A mobile game designed to help people with dementia is to be used by researchers at the University of Bristol<s>"
             ],
             "n_words_checked": 89
           },
@@ -1831,17 +1675,17 @@
         "summary": {
           "completed": 8,
           "total": 10,
-          "factual": 6,
+          "factual": 5,
           "non_factual": 2,
-          "failed": 2,
+          "failed": 3,
           "unknown": 0
         },
         "entity": {
           "label": {
             "Non-factual Hallucination": 2,
-            "Factual Hallucination": 4,
+            "Factual Hallucination": 2,
             "Unknown": 0,
-            "Non-hallucinated": 15,
+            "Non-hallucinated": 12,
             "Intrinsic Hallucination": 0
           },
           "type": {
@@ -1854,27 +1698,27 @@
               "Intrinsic Hallucination": 0
             },
             "DATE": {
-              "total": 4,
+              "total": 3,
               "Non-factual Hallucination": 1,
-              "Factual Hallucination": 2,
+              "Factual Hallucination": 1,
               "Unknown": 0,
               "Non-hallucinated": 1,
               "Intrinsic Hallucination": 0
             },
             "PERSON": {
-              "total": 6,
+              "total": 5,
               "Non-factual Hallucination": 1,
               "Factual Hallucination": 0,
               "Unknown": 0,
-              "Non-hallucinated": 5,
+              "Non-hallucinated": 4,
               "Intrinsic Hallucination": 0
             },
             "GPE": {
-              "total": 7,
+              "total": 5,
               "Non-factual Hallucination": 0,
               "Factual Hallucination": 1,
               "Unknown": 0,
-              "Non-hallucinated": 6,
+              "Non-hallucinated": 4,
               "Intrinsic Hallucination": 0
             },
             "ORDINAL": {
@@ -1891,14 +1735,6 @@
               "Factual Hallucination": 0,
               "Unknown": 0,
               "Non-hallucinated": 1,
-              "Intrinsic Hallucination": 0
-            },
-            "ORG": {
-              "total": 1,
-              "Non-factual Hallucination": 0,
-              "Factual Hallucination": 1,
-              "Unknown": 0,
-              "Non-hallucinated": 0,
               "Intrinsic Hallucination": 0
             }
           }

--- a/results/debug-pegasus-oracle.json
+++ b/results/debug-pegasus-oracle.json
@@ -1,0 +1,699 @@
+{
+  "timestamp": 1654546461.6589289,
+  "args": {
+    "pickled_classifier": "",
+    "classifier_batch_size": 4,
+    "entity_label_match": "contained",
+    "model_path": "google/pegasus-xsum",
+    "max_iterations": 5,
+    "annotate": true,
+    "verbose": true,
+    "batch_size": 2,
+    "test_size": 100,
+    "num_beams": 4,
+    "data_subset": "debug"
+  },
+  "iterations": {
+    "0": {
+      "summaries": {
+        "37066389": {
+          "banned_phrases": [],
+          "summary": "Uzbekistan's Shakhobidin Dusmatov won Olympic gold in the men's flyweight boxing with victory over Colombia's Ivan Martinez.",
+          "generation_metadata": {
+            "score": -1.7804467678070068,
+            "dropped_seqs": [],
+            "n_words_checked": 105
+          },
+          "labeled_entities": [
+            {
+              "ent": "Uzbekistan",
+              "type": "GPE",
+              "start": 0,
+              "end": 10,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            },
+            {
+              "ent": "Shakhobidin",
+              "type": "PERSON",
+              "start": 13,
+              "end": 24,
+              "in_source": false,
+              "label": "Non-factual Hallucination"
+            },
+            {
+              "ent": "Dusmatov",
+              "type": "PERSON",
+              "start": 25,
+              "end": 33,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Colombia",
+              "type": "GPE",
+              "start": 99,
+              "end": 107,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Ivan",
+              "type": "PERSON",
+              "start": 110,
+              "end": 114,
+              "in_source": false,
+              "label": "Non-factual Hallucination"
+            },
+            {
+              "ent": "Martinez",
+              "type": "PERSON",
+              "start": 115,
+              "end": 123,
+              "in_source": true,
+              "label": "Non-factual Hallucination"
+            }
+          ]
+        },
+        "24403775": {
+          "banned_phrases": [],
+          "summary": "Villagers are calling for action to tackle \"nightmare\" traffic caused by the dualling of the A303 at Stonehenge.",
+          "generation_metadata": {
+            "score": -2.189314842224121,
+            "dropped_seqs": [],
+            "n_words_checked": 107
+          },
+          "labeled_entities": [
+            {
+              "ent": "Stonehenge",
+              "type": "FAC",
+              "start": 101,
+              "end": 111,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            }
+          ]
+        },
+        "37615223": {
+          "banned_phrases": [],
+          "summary": "Sam Baldock's first-half header was enough to give Brighton victory over Wolves.",
+          "generation_metadata": {
+            "score": -1.346466064453125,
+            "dropped_seqs": [],
+            "n_words_checked": 100
+          },
+          "labeled_entities": [
+            {
+              "ent": "Sam",
+              "type": "PERSON",
+              "start": 0,
+              "end": 3,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Baldock",
+              "type": "PERSON",
+              "start": 4,
+              "end": 11,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "first-half",
+              "type": "DATE",
+              "start": 14,
+              "end": 24,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            },
+            {
+              "ent": "Brighton",
+              "type": "GPE",
+              "start": 51,
+              "end": 59,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            }
+          ]
+        },
+        "32112735": {
+          "banned_phrases": [],
+          "summary": "One Direction have told fans they'll continue as a four-piece.",
+          "generation_metadata": {
+            "score": -1.7932604551315308,
+            "dropped_seqs": [],
+            "n_words_checked": 77
+          },
+          "labeled_entities": [
+            {
+              "ent": "One",
+              "type": "CARDINAL",
+              "start": 0,
+              "end": 3,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "four",
+              "type": "CARDINAL",
+              "start": 51,
+              "end": 55,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            }
+          ]
+        },
+        "34361828": {
+          "banned_phrases": [],
+          "summary": "A search is under way for the remains of a medieval village which was destroyed by storms in Gower.",
+          "generation_metadata": {
+            "score": -2.6305012702941895,
+            "dropped_seqs": [],
+            "n_words_checked": 99
+          },
+          "labeled_entities": [
+            {
+              "ent": "Gower",
+              "type": "GPE",
+              "start": 93,
+              "end": 98,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            }
+          ]
+        },
+        "17996567": {
+          "banned_phrases": [],
+          "summary": "Plans to cut school bus subsidies in Hampshire have been shelved by the county council.",
+          "generation_metadata": {
+            "score": -2.0206074714660645,
+            "dropped_seqs": [],
+            "n_words_checked": 76
+          },
+          "labeled_entities": [
+            {
+              "ent": "Hampshire",
+              "type": "GPE",
+              "start": 37,
+              "end": 46,
+              "in_source": false,
+              "label": "Non-factual Hallucination"
+            },
+            {
+              "ent": "the county council",
+              "type": "ORG",
+              "start": 68,
+              "end": 86,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            }
+          ]
+        },
+        "36456002": {
+          "banned_phrases": [],
+          "summary": "Romelu Lukaku and Eden Hazard scored as Belgium came from behind to beat Norway in their final warm-up game before Euro 2016.",
+          "generation_metadata": {
+            "score": -0.9374645948410034,
+            "dropped_seqs": [],
+            "n_words_checked": 89
+          },
+          "labeled_entities": [
+            {
+              "ent": "Romelu",
+              "type": "PERSON",
+              "start": 0,
+              "end": 6,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Lukaku",
+              "type": "PERSON",
+              "start": 7,
+              "end": 13,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Belgium",
+              "type": "GPE",
+              "start": 40,
+              "end": 47,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Norway",
+              "type": "GPE",
+              "start": 73,
+              "end": 79,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Euro 2016",
+              "type": "LAW",
+              "start": 115,
+              "end": 124,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            }
+          ]
+        },
+        "36396523": {
+          "banned_phrases": [],
+          "summary": "Kaka has been added to Brazil's squad for the Copa America in the United States.",
+          "generation_metadata": {
+            "score": -1.20772385597229,
+            "dropped_seqs": [],
+            "n_words_checked": 78
+          },
+          "labeled_entities": [
+            {
+              "ent": "Kaka",
+              "type": "PERSON",
+              "start": 0,
+              "end": 4,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Brazil",
+              "type": "GPE",
+              "start": 23,
+              "end": 29,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "the Copa America",
+              "type": "ORG",
+              "start": 42,
+              "end": 58,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            },
+            {
+              "ent": "the United States",
+              "type": "GPE",
+              "start": 62,
+              "end": 79,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            }
+          ]
+        },
+        "36203675": {
+          "banned_phrases": [],
+          "summary": "A new mobile game is being used to help dementia research.",
+          "generation_metadata": {
+            "score": -2.2486746311187744,
+            "dropped_seqs": [],
+            "n_words_checked": 63
+          },
+          "labeled_entities": []
+        },
+        "39368095": {
+          "banned_phrases": [],
+          "summary": "Abertay University in Dundee has been named the best university in the world for its postgraduate courses in computer games development.",
+          "generation_metadata": {
+            "score": -1.5793300867080688,
+            "dropped_seqs": [],
+            "n_words_checked": 90
+          },
+          "labeled_entities": [
+            {
+              "ent": "Dundee",
+              "type": "GPE",
+              "start": 22,
+              "end": 28,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            }
+          ]
+        }
+      },
+      "stats": {
+        "summary": {
+          "completed": 8,
+          "total": 10,
+          "factual": 8,
+          "non_factual": 2,
+          "failed": 0,
+          "unknown": 0
+        },
+        "entity": {
+          "label": {
+            "Non-factual Hallucination": 4,
+            "Factual Hallucination": 6,
+            "Unknown": 0,
+            "Non-hallucinated": 16,
+            "Intrinsic Hallucination": 0
+          },
+          "type": {
+            "PERSON": {
+              "total": 9,
+              "Non-factual Hallucination": 3,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 6,
+              "Intrinsic Hallucination": 0
+            },
+            "GPE": {
+              "total": 10,
+              "Non-factual Hallucination": 1,
+              "Factual Hallucination": 3,
+              "Unknown": 0,
+              "Non-hallucinated": 6,
+              "Intrinsic Hallucination": 0
+            },
+            "FAC": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 1,
+              "Intrinsic Hallucination": 0
+            },
+            "DATE": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 1,
+              "Unknown": 0,
+              "Non-hallucinated": 0,
+              "Intrinsic Hallucination": 0
+            },
+            "CARDINAL": {
+              "total": 2,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 2,
+              "Intrinsic Hallucination": 0
+            },
+            "ORG": {
+              "total": 2,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 2,
+              "Unknown": 0,
+              "Non-hallucinated": 0,
+              "Intrinsic Hallucination": 0
+            },
+            "LAW": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 1,
+              "Intrinsic Hallucination": 0
+            }
+          }
+        }
+      }
+    },
+    "1": {
+      "summaries": {
+        "37066389": {
+          "banned_phrases": [
+            "Ivan",
+            "Martinez",
+            "Shakhobidin"
+          ],
+          "summary": "Uzbekistan's Fedor Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Jose AlfredoMartinez.",
+          "generation_metadata": {
+            "score": -2.9797425270080566,
+            "dropped_seqs": [
+              "<pad> Uzbekistan's Shakhobidin",
+              "<pad> Uzbekistan's Islam Dusmatov beat Colombia's Ivan",
+              "<pad> Uzbekistan's Fedor Dusmatov beat Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's flyweight boxing with victory over Colombia's Ivan",
+              "<pad> Uzbekistan's Fedor Dusmatov won Olympic gold in the men's flyweight boxing with victory over Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Ivan",
+              "<pad> Uzbekistan's Fedor Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Francisco Martinez",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Jose Martinez",
+              "<pad> Uzbekistan's Fedor Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Jose Martinez",
+              "<pad> Uzbekistan's Fedor Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Jose Manuel Martinez",
+              "<pad> Uzbekistan's Fedor Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Jose Alfredo Martinez",
+              "<pad> Uzbekistan's Fedor Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Jose Roberto Martinez"
+            ],
+            "n_words_checked": 111
+          },
+          "labeled_entities": [
+            {
+              "ent": "Uzbekistan",
+              "type": "GPE",
+              "start": 0,
+              "end": 10,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            },
+            {
+              "ent": "Fedor",
+              "type": "PERSON",
+              "start": 13,
+              "end": 18,
+              "in_source": false,
+              "label": "Non-factual Hallucination"
+            },
+            {
+              "ent": "Dusmatov",
+              "type": "PERSON",
+              "start": 19,
+              "end": 27,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Colombia",
+              "type": "GPE",
+              "start": 99,
+              "end": 107,
+              "in_source": true,
+              "label": "Non-hallucinated"
+            },
+            {
+              "ent": "Jose",
+              "type": "GPE",
+              "start": 110,
+              "end": 114,
+              "in_source": false,
+              "label": "Non-factual Hallucination"
+            }
+          ]
+        },
+        "17996567": {
+          "banned_phrases": [
+            "Hampshire"
+          ],
+          "summary": "Plans to cut school bus subsidies in Kent have been shelved by the county council.",
+          "generation_metadata": {
+            "score": -1.9709789752960205,
+            "dropped_seqs": [
+              "<pad> Plans to cut school bus subsidies in Hampshire",
+              "<pad> Plans to cut school transport subsidies in Hampshire"
+            ],
+            "n_words_checked": 80
+          },
+          "labeled_entities": [
+            {
+              "ent": "the county council",
+              "type": "ORG",
+              "start": 63,
+              "end": 81,
+              "in_source": false,
+              "label": "Factual Hallucination"
+            }
+          ]
+        }
+      },
+      "stats": {
+        "summary": {
+          "completed": 9,
+          "total": 10,
+          "factual": 9,
+          "non_factual": 1,
+          "failed": 0,
+          "unknown": 0
+        },
+        "entity": {
+          "label": {
+            "Non-factual Hallucination": 2,
+            "Factual Hallucination": 6,
+            "Unknown": 0,
+            "Non-hallucinated": 16,
+            "Intrinsic Hallucination": 0
+          },
+          "type": {
+            "PERSON": {
+              "total": 7,
+              "Non-factual Hallucination": 1,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 6,
+              "Intrinsic Hallucination": 0
+            },
+            "GPE": {
+              "total": 10,
+              "Non-factual Hallucination": 1,
+              "Factual Hallucination": 3,
+              "Unknown": 0,
+              "Non-hallucinated": 6,
+              "Intrinsic Hallucination": 0
+            },
+            "FAC": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 1,
+              "Intrinsic Hallucination": 0
+            },
+            "DATE": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 1,
+              "Unknown": 0,
+              "Non-hallucinated": 0,
+              "Intrinsic Hallucination": 0
+            },
+            "CARDINAL": {
+              "total": 2,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 2,
+              "Intrinsic Hallucination": 0
+            },
+            "ORG": {
+              "total": 2,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 2,
+              "Unknown": 0,
+              "Non-hallucinated": 0,
+              "Intrinsic Hallucination": 0
+            },
+            "LAW": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 1,
+              "Intrinsic Hallucination": 0
+            }
+          }
+        }
+      }
+    },
+    "2": {
+      "summaries": {
+        "37066389": {
+          "banned_phrases": [
+            "Martinez",
+            "Jose",
+            "Ivan",
+            "Fedor",
+            "Shakhobidin"
+          ],
+          "summary": "<Failed generation: blocked all beams>",
+          "generation_metadata": {
+            "score": -Infinity,
+            "dropped_seqs": [
+              "<pad> Uzbekistan's Fedor",
+              "<pad> Uzbekistan's Shakhobidin",
+              "<pad> Uzbekistan's Islam Dusmatov beat Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov beat Colombia's Jose",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's flyweight boxing with victory over Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-heavyweight boxing, beating Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-heavyweight boxing, beating Colombia's Jose",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-heavyweight boxing with victory over Colombia's Ivan",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-flyweight boxing with victory over Colombia's Jose",
+              "<pad> Uzbekistan's Islam Dusmatov won Olympic gold in the men's light-heavyweight boxing with victory over Colombia's Jose"
+            ],
+            "n_words_checked": 112
+          },
+          "labeled_entities": []
+        }
+      },
+      "stats": {
+        "summary": {
+          "completed": 10,
+          "total": 10,
+          "factual": 9,
+          "non_factual": 0,
+          "failed": 1,
+          "unknown": 0
+        },
+        "entity": {
+          "label": {
+            "Non-factual Hallucination": 0,
+            "Factual Hallucination": 5,
+            "Unknown": 0,
+            "Non-hallucinated": 14,
+            "Intrinsic Hallucination": 0
+          },
+          "type": {
+            "FAC": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 1,
+              "Intrinsic Hallucination": 0
+            },
+            "DATE": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 1,
+              "Unknown": 0,
+              "Non-hallucinated": 0,
+              "Intrinsic Hallucination": 0
+            },
+            "PERSON": {
+              "total": 5,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 5,
+              "Intrinsic Hallucination": 0
+            },
+            "GPE": {
+              "total": 7,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 2,
+              "Unknown": 0,
+              "Non-hallucinated": 5,
+              "Intrinsic Hallucination": 0
+            },
+            "CARDINAL": {
+              "total": 2,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 2,
+              "Intrinsic Hallucination": 0
+            },
+            "ORG": {
+              "total": 2,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 2,
+              "Unknown": 0,
+              "Non-hallucinated": 0,
+              "Intrinsic Hallucination": 0
+            },
+            "LAW": {
+              "total": 1,
+              "Non-factual Hallucination": 0,
+              "Factual Hallucination": 0,
+              "Unknown": 0,
+              "Non-hallucinated": 1,
+              "Intrinsic Hallucination": 0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -57,7 +57,7 @@ DEBUG_IDS = {
     "32112735",  # One direction split
     "36203675",  # Dementia mobile game researchers
     "17996567",
-    "36396523",
+    "36396523",  # Kaka
     "39368095",
     "37066389",  # "Omar Martinez"
     "37615223",
@@ -159,7 +159,4 @@ def load_summaries_from_logs(path, max_iterations=5):
 
 
 def get_gold_xsum_data():
-    return (
-        get_summaries("xsum", "gold"),
-        get_summary_metrics("xsum", "gold")
-    )
+    return (get_summaries("xsum", "gold"), get_summary_metrics("xsum", "gold"))

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -52,7 +52,7 @@ def persist_example_with_probs(
 
 DEBUG_IDS = {
     "34361828",
-    "36456002",
+    "36456002",  # Lukaku
     "24403775",
     "32112735",  # One direction split
     "36203675",  # Dementia mobile game researchers

--- a/src/generation_utils.py
+++ b/src/generation_utils.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, LogitsProcessorList
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, LogitsProcessorList, PegasusTokenizerFast
 from src.word_logits_processor import WordLogitsProcessor
 
 
@@ -64,7 +64,7 @@ def generate_summaries(
     model.to(device)
     inputs = tokenizer(
         docs_to_summarize,
-        max_length=1024,
+        max_length=tokenizer.model_max_length,
         truncation=True,
         return_tensors="pt",
         padding=True,

--- a/src/word_logits_processor.py
+++ b/src/word_logits_processor.py
@@ -4,21 +4,17 @@ from transformers import LogitsProcessor
 from src.beam_validators import WordValidator
 
 
-SPLIT_WORD_TOKENS = {
-    ' ',
-    '.',
-    ',',
-    '_',
-    '?',
-    '!',
-    '\''
-}
+SPLIT_WORD_TOKENS = {" ", ".", ",", "_", "?", "!", "'"}
+
 
 def should_backtrack(subword: str):
     return not subword.startswith(" ")
 
+
 def is_subword_ending(subword: str):
     return subword.startswith(" ") or subword.endswith(" ")
+
+
 class WordLogitsProcessor(LogitsProcessor):
     r"""
     [`WordLogitsProcessor`] enforcing constraints on words during beam search
@@ -36,70 +32,70 @@ class WordLogitsProcessor(LogitsProcessor):
         self.tokenizer = tokenizer
         self.word_validator = word_validator
         self.num_beams = num_beams
-        self.excluded_beams_by_input_idx = defaultdict(list)
+        self.excluded_beams_by_input_idx = defaultdict(lambda: list())
         self.words_to_check_by_input_idx = defaultdict(lambda: 0)
         self.failed_sequences = set()
 
     def is_valid_beam(
         self,
-        input_idx, # input idx being processed
+        input_idx,  # input idx being processed
         sequence,  # sequence generated so far
         token_id,  # next token to be generated (argmax of beam_scores)
-        beam_scores # probability of all tokens to be generated
+        beam_scores,  # probability of all tokens to be generated
     ):
         """
-            Check whether beam is valid according to the passed validators.
+        Check whether beam is valid according to the passed validators.
 
-            To enable validating on a word-level, this method backtracks
-            to collect the predicted word when it detects that the predicted
-            subword (token) is a word ending.
+        To enable validating on a word-level, this method backtracks
+        to collect the predicted word when it detects that the predicted
+        subword (token) is a word ending.
         """
-        # Token-level checks
-        # if token_id in self.banned_token_ids:
-        #     return False
 
-        # Word-level checks
-        current_subword = self.tokenizer.decode(token_id)
-        backtrack_word = ""
-        is_subword_ending = False
-        for char in current_subword:
+        # Begin by checking whether tokens
+        # to-be-generated indicate a phrase ending
+        if "pegasus" in self.tokenizer.name_or_path:
+            # For pegasus we need to include the previous token
+            # since spaces are not included when decoding a single token:
+            # https://github.com/huggingface/tokenizers/issues/826
+            to_be_generated = self.tokenizer.decode(
+                [sequence[-1], token_id], skip_special_tokens=True
+            )
+        else:
+            to_be_generated = self.tokenizer.decode(token_id, skip_special_tokens=True)
+        phrase_ending_idx = -1
+        for j, char in enumerate(reversed(to_be_generated)):
             if char in SPLIT_WORD_TOKENS:
-                is_subword_ending = True
+                phrase_ending_idx = j + 1
                 break
-            else:
-                backtrack_word += char
 
-        # if the predicted subword indicates a word ending
-        # backtrack to collect the predicted word
-        backtrack_done = False
-        if is_subword_ending:
-            prev_subword_idx = len(sequence) - 1
-            while prev_subword_idx != 0 and not backtrack_done:
-                prev_token_id = sequence[prev_subword_idx]
-                prev_subword = self.tokenizer.decode(prev_token_id)
-                prev_char_idx = len(prev_subword) - 1
-                while prev_char_idx >= 0:
-                    prev_char = prev_subword[prev_char_idx]
-                    if prev_char not in SPLIT_WORD_TOKENS:
-                        backtrack_word = prev_char + backtrack_word
+        # if the predicted token indicates a phrase ending
+        # backtrack to collect the phrase
+        if phrase_ending_idx != -1:
+            backtrack_phrase = ""
+            candidate_gen = self.tokenizer.decode(
+                list(sequence) + [token_id], skip_special_tokens=True
+            )[:-phrase_ending_idx]
+            prev_char_idx = len(candidate_gen) - 1
+
+            while prev_char_idx >= 0:
+                prev_char = candidate_gen[prev_char_idx]
+                if prev_char not in SPLIT_WORD_TOKENS:
+                    backtrack_phrase = prev_char + backtrack_phrase
+                else:
+                    # We encountered a split-word token
+                    # stop backtracking UNLESS the backtracked word
+                    # is an invalid phrase ending
+                    if self.word_validator.is_maybe_invalid_phrase_ending(
+                        prev_char + backtrack_phrase, input_idx
+                    ):
+                        backtrack_phrase = prev_char + backtrack_phrase
                     else:
-                        if self.word_validator.is_maybe_invalid_phrase_ending(
-                            prev_char + backtrack_word,
-                            input_idx
-                        ):
-                            backtrack_word = prev_char + backtrack_word
-                        else:
-                            backtrack_done = True
-                            break
-                    prev_char_idx -= 1
-                prev_subword_idx -= 1
+                        break
+                prev_char_idx -= 1
             self.words_to_check_by_input_idx[input_idx] += 1
             # Call validator to check whether the word is valid
             if not self.word_validator.is_valid_word(
-                backtrack_word,
-                input_idx,
-                sequence,
-                beam_scores
+                backtrack_phrase, input_idx, sequence, beam_scores
             ):
                 return False
         return True
@@ -116,17 +112,16 @@ class WordLogitsProcessor(LogitsProcessor):
             for prob, idx in zip(top_k[0], top_k[1]):
                 input_idx = beam_idx // self.num_beams
                 if not self.is_valid_beam(
-                    input_idx,
-                    beam_input_ids,
-                    idx.item(),
-                    scores[beam_idx]
+                    input_idx, beam_input_ids, idx.item(), scores[beam_idx]
                 ):
                     scores[beam_idx, :] = -float("inf")
-                    self.excluded_beams_by_input_idx[input_idx].append((
-                        beam_input_ids,
-                        idx.item(),
-                        prob.item(),
-                    ))
+                    self.excluded_beams_by_input_idx[input_idx].append(
+                        (
+                            beam_input_ids,
+                            idx.item(),
+                            prob.item(),
+                        )
+                    )
                     blocked_beams_by_input_idx[input_idx] += 1
 
         for input_idx, n_blocked in blocked_beams_by_input_idx.items():


### PR DESCRIPTION
- Infer tokenization max length from tokenizer (pegasus is pretrained with 512, bart with 1024)
- Refactor Phrase logits processor & backtracking to work on a word-level since Pegasus tokenizer doesn't include spaces per token
- Added tests for Pegasus banned phrases
- Added debug results for Pegasus
- Fixed bug in handling of padded beams